### PR TITLE
ci(release): fix goreleaser v2 pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
-          go-version: 1.19
+          go-version-file: go.mod
 
       - name: Get Go environment
         id: go-env
         run: |
-          echo "::set-output name=cache::$(go env GOCACHE)"
-          echo "::set-output name=modcache::$(go env GOMODCACHE)"
+          echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "modcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
       - name: Set up cache
         uses: actions/cache@v5.0.5
@@ -39,7 +39,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload assets

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,12 +1,11 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 project_name: teled
 before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
 builds:
   - env:
       - CGO_ENABLED=0
@@ -18,11 +17,17 @@ builds:
       - amd64
       - arm64
       - riscv64
+    ignore:
+      # riscv64 is only supported on linux.
+      - goos: windows
+        goarch: riscv64
+      - goos: darwin
+        goarch: riscv64
     main: ./cmd/teled
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Context

The release workflow has been failing on tag pushes (e.g. `v0.3.0`) with:

```
command failed  error=unknown flag: --rm-dist
```

The `goreleaser/goreleaser-action@v6` action locks `version: latest` to `~> v2`, and goreleaser v2 removed the `--rm-dist` flag and now requires `version: 2` in the config. As a result no binaries have been released.

## Changes

- Use `--clean` instead of the removed `--rm-dist` flag
- Add `version: 2` to `.goreleaser.yaml` (required by v2)
- Ignore invalid `riscv64` combinations for windows and darwin (riscv64 only builds on linux)
- Rename deprecated `snapshot.name_template` → `version_template`
- Use `go-version-file: go.mod` instead of pinned `1.19` (go.mod is `1.25`; with `GOTOOLCHAIN=local` the old pin would fail)
- Replace deprecated `::set-output` with `$GITHUB_OUTPUT`
- Drop the `go generate` before-hook (no `//go:generate` directives in the tree)

## Verification

Validated locally with goreleaser v2:

```
goreleaser check                                  # 1 configuration file(s) validated
goreleaser release --snapshot --clean --skip=publish  # release succeeded after 51s
```

All 7 targets build (linux amd64/arm64/riscv64, windows amd64/arm64, darwin amd64/arm64) plus deb/rpm/apk packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)