### PR TITLE
feat(packaging): systemd unit, env file and teled user for nfpm targets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,3 +44,24 @@ nfpms:
       - apk
       - deb
       - rpm
+    contents:
+      - src: ./init/teled.service
+        dst: /usr/lib/systemd/system/teled.service
+      - src: ./init/teled.env
+        dst: /etc/teled/teled.env
+        type: "config|noreplace"
+        file_info:
+          mode: 0640
+          owner: root
+          group: teled
+      - dst: /var/lib/teled
+        type: dir
+        file_info:
+          mode: 0750
+          owner: teled
+          group: teled
+    scripts:
+      preinstall: ./scripts/preinstall.sh
+      postinstall: ./scripts/postinstall.sh
+      preremove: ./scripts/preremove.sh
+      postremove: ./scripts/postremove.sh

--- a/init/teled.env
+++ b/init/teled.env
@@ -1,0 +1,19 @@
+# Configuration for the teled systemd service.
+# After editing, run: systemctl restart teled
+
+# PostgreSQL DSN (e.g. postgres://user:pass@host:5432/teled?sslmode=disable).
+# If empty, auth keys are kept in memory only.
+DATABASE_URL=
+
+# Hostname advertised by the server.
+TELED_HOST=localhost
+
+# TCP port to listen on.
+TELED_PORT=10443
+
+# Path to the PEM-encoded RSA private key.
+# Generate one with: teled keys generate > /etc/teled/private.pem
+TELED_KEY=/etc/teled/private.pem
+
+# Directory for media object storage.
+TELED_OBJECT_STORE_DIR=/var/lib/teled/objects

--- a/init/teled.service
+++ b/init/teled.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=teled — Telegram Server in Go
+Documentation=https://github.com/gotd/teled
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=teled
+Group=teled
+EnvironmentFile=/etc/teled/teled.env
+ExecStart=/usr/bin/teled --host ${TELED_HOST} --port ${TELED_PORT} --key ${TELED_KEY} --object-store-dir ${TELED_OBJECT_STORE_DIR}
+WorkingDirectory=/var/lib/teled
+Restart=on-failure
+RestartSec=5s
+
+# Hardening.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/teled
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Prepare the data directory and reload systemd. The service is intentionally
+# NOT enabled or started: the operator must provide a private key first
+# (see /etc/teled/teled.env) and then run `systemctl enable --now teled`.
+set -e
+
+mkdir -p /var/lib/teled/objects
+chown -R teled:teled /var/lib/teled
+chmod 0750 /var/lib/teled
+
+if command -v systemctl >/dev/null 2>&1; then
+	systemctl daemon-reload >/dev/null 2>&1 || true
+fi

--- a/scripts/postremove.sh
+++ b/scripts/postremove.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Reload systemd after the unit file has been removed.
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+	systemctl daemon-reload >/dev/null 2>&1 || true
+fi

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Create the system user and group for teled before files are unpacked,
+# so packaged files can be owned by it.
+set -e
+
+if ! getent group teled >/dev/null 2>&1; then
+	groupadd --system teled 2>/dev/null \
+		|| addgroup -S teled 2>/dev/null \
+		|| true
+fi
+
+if ! getent passwd teled >/dev/null 2>&1; then
+	useradd --system --gid teled --home-dir /var/lib/teled \
+		--no-create-home --shell /usr/sbin/nologin \
+		--comment "teled server" teled 2>/dev/null \
+		|| adduser -S -D -H -G teled -h /var/lib/teled -s /sbin/nologin teled 2>/dev/null \
+		|| true
+fi

--- a/scripts/preremove.sh
+++ b/scripts/preremove.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Stop and disable the service before removal, if it was ever enabled.
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+	systemctl stop teled.service >/dev/null 2>&1 || true
+	systemctl disable teled.service >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
## Context

The nfpm targets (deb/rpm/apk) previously shipped only the binary. This adds a complete service setup so the packages are installable and ready to run after the operator provides a private key.

## What's included

On install, packages now:

- **Create a `teled` system user/group** (`scripts/preinstall.sh`, portable across `useradd` and busybox `adduser`).
- **Install a systemd unit** at `/usr/lib/systemd/system/teled.service`, running as `teled` with basic sandboxing (`NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, `ReadWritePaths=/var/lib/teled`).
- **Install `/etc/teled/teled.env`** (config, `noreplace`, `root:teled 0640`) holding `DATABASE_URL` and the `TELED_*` values consumed by the unit's `ExecStart`.
- **Create `/var/lib/teled`** (`0750`, `teled:teled`) for media object storage.

The unit's `ExecStart` maps env to the existing flags:
`teled --host ${TELED_HOST} --port ${TELED_PORT} --key ${TELED_KEY} --object-store-dir ${TELED_OBJECT_STORE_DIR}`.
`DATABASE_URL` is picked up automatically via the flag default.

## Not enabled by default

The service is **not** enabled or started on install. `postinstall` only runs `systemctl daemon-reload`. The operator must first generate a key:

```
teled keys generate > /etc/teled/private.pem
systemctl enable --now teled
```

## Verification

Built a snapshot and inspected the `.deb`:

```
$ dpkg-deb -c dist/teled_*_linux_amd64.deb
-rw-r----- root/teled   ./etc/teled/teled.env
-rwxr-xr-x root/root    ./usr/bin/teled
-rw-rw-r-- root/root    ./usr/lib/systemd/system/teled.service
drwxr-x--- teled/teled  ./var/lib/teled/
$ dpkg-deb --info dist/teled_*_linux_amd64.deb   # preinst, postinst, prerm, postrm present
```

`goreleaser check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)