### PR TITLE
feat(obs): propagate OpenTelemetry tracing and metrics across layers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,10 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/metric v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.28.0
@@ -118,7 +122,6 @@ require (
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.44.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.44.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 // indirect
@@ -131,11 +134,8 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect

--- a/internal/db/obs.go
+++ b/internal/db/obs.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/gotd/teled/internal/obs"
+)
+
+const instrumentationName = "github.com/gotd/teled/internal/db"
+
+var (
+	tracer = otel.Tracer(instrumentationName)
+	meter  = otel.Meter(instrumentationName)
+
+	// queryDuration records database query latency in seconds, labeled by the
+	// SQL operation (SELECT, INSERT, ...). A histogram also carries the count.
+	queryDuration = obs.Must(meter.Float64Histogram("teled.db.query.duration",
+		metric.WithDescription("Duration of database queries."),
+		metric.WithUnit("s"),
+	))
+)
+
+// queryTracer implements pgx.QueryTracer to open a span and record metrics for
+// every query executed through the pool, covering all DB methods at once.
+type queryTracer struct{}
+
+var _ pgx.QueryTracer = queryTracer{}
+
+type queryTraceKey struct{}
+
+type queryTraceData struct {
+	span  trace.Span
+	start time.Time
+	op    string
+}
+
+// TraceQueryStart starts a client span for the query.
+func (queryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	op := sqlOperation(data.SQL)
+	ctx, span := tracer.Start(ctx, "db.query "+op, trace.WithSpanKind(trace.SpanKindClient))
+	span.SetAttributes(
+		attribute.String("db.system", "postgresql"),
+		attribute.String("db.operation", op),
+		attribute.String("db.statement", data.SQL),
+	)
+	return context.WithValue(ctx, queryTraceKey{}, &queryTraceData{span: span, start: time.Now(), op: op})
+}
+
+// TraceQueryEnd ends the span and records the query duration metric.
+func (queryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+	d, ok := ctx.Value(queryTraceKey{}).(*queryTraceData)
+	if !ok {
+		return
+	}
+	if data.Err != nil {
+		d.span.RecordError(data.Err)
+		d.span.SetStatus(codes.Error, data.Err.Error())
+	}
+	d.span.End()
+	queryDuration.Record(ctx, time.Since(d.start).Seconds(),
+		metric.WithAttributes(attribute.String("db.operation", d.op)))
+}
+
+// sqlOperation returns the leading SQL keyword (e.g. SELECT) for low-cardinality
+// labeling, or "UNKNOWN" if the statement is empty.
+func sqlOperation(sql string) string {
+	sql = strings.TrimSpace(sql)
+	if sql == "" {
+		return "UNKNOWN"
+	}
+	if i := strings.IndexAny(sql, " \t\r\n"); i > 0 {
+		sql = sql[:i]
+	}
+	return strings.ToUpper(sql)
+}

--- a/internal/db/open.go
+++ b/internal/db/open.go
@@ -18,6 +18,9 @@ func Open(ctx context.Context, uri string) (*pgxpool.Pool, error) {
 	cfg.MinConns = 0
 	cfg.MaxConnLifetime = 2 * time.Minute
 
+	// Trace every query and record query metrics.
+	cfg.ConnConfig.Tracer = queryTracer{}
+
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "new pool")

--- a/internal/mtproto/conn.go
+++ b/internal/mtproto/conn.go
@@ -36,7 +36,9 @@ func (s *Server) sendProtoError(ctx context.Context, conn transport.Conn, code i
 // serveConn serves a single client connection until it is closed.
 func (s *Server) serveConn(ctx context.Context, conn transport.Conn) error {
 	s.log.Debug("Client connected")
+	activeConns.Add(ctx, 1)
 	defer func() {
+		activeConns.Add(ctx, -1)
 		s.registry.removeConn(conn)
 		_ = conn.Close()
 		s.log.Debug("Client disconnected")

--- a/internal/mtproto/handle.go
+++ b/internal/mtproto/handle.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 
 	"github.com/go-faster/errors"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
@@ -16,8 +18,20 @@ import (
 	"github.com/gotd/td/transport"
 )
 
-// rpcHandle decrypts an incoming encrypted message and dispatches it.
-func (s *Server) rpcHandle(ctx context.Context, c transport.Conn, b *bin.Buffer) error {
+// rpcHandle decrypts an incoming encrypted message and dispatches it. It opens
+// the root span for the request: there is no inbound trace context in the
+// MTProto protocol, so each encrypted message starts a new trace.
+func (s *Server) rpcHandle(ctx context.Context, c transport.Conn, b *bin.Buffer) (rerr error) {
+	ctx, span := tracer.Start(ctx, "mtproto.handle", trace.WithSpanKind(trace.SpanKindServer))
+	defer func() {
+		if rerr != nil {
+			span.RecordError(rerr)
+			span.SetStatus(codes.Error, rerr.Error())
+		}
+		span.End()
+	}()
+	messages.Add(ctx, 1)
+
 	m := &crypto.EncryptedMessage{}
 	if err := m.DecodeWithoutCopy(b); err != nil {
 		return errors.Wrap(err, "decode encrypted message")

--- a/internal/mtproto/obs.go
+++ b/internal/mtproto/obs.go
@@ -1,0 +1,26 @@
+package mtproto
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/gotd/teled/internal/obs"
+)
+
+const instrumentationName = "github.com/gotd/teled/internal/mtproto"
+
+var (
+	tracer = otel.Tracer(instrumentationName)
+	meter  = otel.Meter(instrumentationName)
+
+	// activeConns tracks the number of currently connected clients.
+	activeConns = obs.Must(meter.Int64UpDownCounter("teled.mtproto.connections.active",
+		metric.WithDescription("Number of active client connections."),
+		metric.WithUnit("{connection}"),
+	))
+	// messages counts decrypted MTProto messages handled by the server.
+	messages = obs.Must(meter.Int64Counter("teled.mtproto.messages",
+		metric.WithDescription("Number of decrypted MTProto messages handled."),
+		metric.WithUnit("{message}"),
+	))
+)

--- a/internal/objstore/fs.go
+++ b/internal/objstore/fs.go
@@ -39,7 +39,10 @@ func (s *FS) path(key string) string {
 }
 
 // Put implements teled.ObjectStore. It writes atomically via a temp file.
-func (s *FS) Put(_ context.Context, key string, r io.Reader, _ int64, _ teled.PutOptions) error {
+func (s *FS) Put(ctx context.Context, key string, r io.Reader, _ int64, _ teled.PutOptions) (rerr error) {
+	done := observe(ctx, "put")
+	defer func() { done(rerr) }()
+
 	dst := s.path(key)
 	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
 		return errors.Wrap(err, "mkdir")
@@ -68,7 +71,10 @@ func (s *FS) Put(_ context.Context, key string, r io.Reader, _ int64, _ teled.Pu
 }
 
 // Get implements teled.ObjectStore.
-func (s *FS) Get(_ context.Context, key string) (io.ReadCloser, error) {
+func (s *FS) Get(ctx context.Context, key string) (_ io.ReadCloser, rerr error) {
+	done := observe(ctx, "get")
+	defer func() { done(rerr) }()
+
 	f, err := os.Open(s.path(key))
 	if err != nil {
 		return nil, errors.Wrap(err, "open")
@@ -77,7 +83,10 @@ func (s *FS) Get(_ context.Context, key string) (io.ReadCloser, error) {
 }
 
 // GetRange implements teled.ObjectStore, returning length bytes from offset.
-func (s *FS) GetRange(_ context.Context, key string, offset, length int64) (io.ReadCloser, error) {
+func (s *FS) GetRange(ctx context.Context, key string, offset, length int64) (_ io.ReadCloser, rerr error) {
+	done := observe(ctx, "get_range")
+	defer func() { done(rerr) }()
+
 	f, err := os.Open(s.path(key))
 	if err != nil {
 		return nil, errors.Wrap(err, "open")
@@ -90,7 +99,10 @@ func (s *FS) GetRange(_ context.Context, key string, offset, length int64) (io.R
 }
 
 // Stat implements teled.ObjectStore.
-func (s *FS) Stat(_ context.Context, key string) (teled.ObjectInfo, error) {
+func (s *FS) Stat(ctx context.Context, key string) (_ teled.ObjectInfo, rerr error) {
+	done := observe(ctx, "stat")
+	defer func() { done(rerr) }()
+
 	fi, err := os.Stat(s.path(key))
 	if err != nil {
 		return teled.ObjectInfo{}, errors.Wrap(err, "stat")
@@ -99,7 +111,10 @@ func (s *FS) Stat(_ context.Context, key string) (teled.ObjectInfo, error) {
 }
 
 // Delete implements teled.ObjectStore. A missing object is not an error.
-func (s *FS) Delete(_ context.Context, key string) error {
+func (s *FS) Delete(ctx context.Context, key string) (rerr error) {
+	done := observe(ctx, "delete")
+	defer func() { done(rerr) }()
+
 	if err := os.Remove(s.path(key)); err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "remove")
 	}

--- a/internal/objstore/obs.go
+++ b/internal/objstore/obs.go
@@ -1,0 +1,46 @@
+package objstore
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/gotd/teled/internal/obs"
+)
+
+const instrumentationName = "github.com/gotd/teled/internal/objstore"
+
+var (
+	tracer = otel.Tracer(instrumentationName)
+	meter  = otel.Meter(instrumentationName)
+
+	// opDuration records object store operation latency in seconds, labeled by
+	// operation (put, get, ...).
+	opDuration = obs.Must(meter.Float64Histogram("teled.objstore.duration",
+		metric.WithDescription("Duration of object store operations."),
+		metric.WithUnit("s"),
+	))
+)
+
+// observe starts a span for an object store operation and returns a function
+// that ends it and records the operation duration. Pass the operation's error
+// to the returned function so failures are recorded on the span.
+func observe(ctx context.Context, op string) func(error) {
+	ctx, span := tracer.Start(ctx, "objstore."+op, trace.WithSpanKind(trace.SpanKindClient))
+	span.SetAttributes(attribute.String("objstore.operation", op))
+	start := time.Now()
+	return func(err error) {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+		opDuration.Record(ctx, time.Since(start).Seconds(),
+			metric.WithAttributes(attribute.String("objstore.operation", op)))
+	}
+}

--- a/internal/objstore/obs_test.go
+++ b/internal/objstore/obs_test.go
@@ -1,0 +1,44 @@
+package objstore_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/gotd/teled"
+	"github.com/gotd/teled/internal/objstore"
+)
+
+// TestFSTracing verifies that object store operations emit spans through the
+// global tracer provider.
+func TestFSTracing(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	ctx := context.Background()
+	fs, err := objstore.NewFS(t.TempDir())
+	require.NoError(t, err)
+
+	require.NoError(t, fs.Put(ctx, "abcd-key", bytes.NewBufferString("payload"), 7, teled.PutOptions{}))
+	rc, err := fs.Get(ctx, "abcd-key")
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, rc)
+	require.NoError(t, rc.Close())
+	require.NoError(t, fs.Delete(ctx, "abcd-key"))
+
+	require.NoError(t, tp.ForceFlush(ctx))
+	var names []string
+	for _, s := range sr.Ended() {
+		names = append(names, s.Name())
+	}
+	require.Subset(t, names, []string{"objstore.put", "objstore.get", "objstore.delete"})
+}

--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -1,0 +1,13 @@
+// Package obs holds small helpers shared by the OpenTelemetry instrumentation
+// across teled's internal packages.
+package obs
+
+// Must panics if err is non-nil, otherwise returns v. It is meant for
+// constructing OpenTelemetry instruments at package init, where an error means
+// a programming mistake (e.g. an invalid instrument name).
+func Must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/internal/rpc/handler.go
+++ b/internal/rpc/handler.go
@@ -3,8 +3,12 @@ package rpc
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-faster/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
 	"github.com/gotd/td/bin"
@@ -50,6 +54,19 @@ func (h *Handler) OnMessage(server *mtproto.Server, req *mtproto.Request) error 
 	ctx := context.WithValue(req.RequestCtx, keyReq{}, req)
 	ctx = context.WithValue(ctx, keySrv{}, server)
 
+	// Resolve the RPC method name from the request type id for span naming and
+	// metric labeling.
+	method := "unknown"
+	if id, err := req.Buf.PeekID(); err == nil {
+		if name := tg.TypesMap()[id]; name != "" {
+			method = name
+		}
+	}
+
+	ctx, span := tracer.Start(ctx, method)
+	defer span.End()
+	start := time.Now()
+
 	// Register the session for push if it belongs to a logged-in user.
 	if h.db != nil {
 		if userID, ok, err := h.db.SessionUserID(ctx, req.Session.AuthKey.ID); err == nil && ok {
@@ -58,6 +75,20 @@ func (h *Handler) OnMessage(server *mtproto.Server, req *mtproto.Request) error 
 	}
 
 	e, err := h.dispatcher.Handle(ctx, req.Buf)
+
+	status := "ok"
+	if err != nil {
+		status = "error"
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	rpcDuration.Record(ctx, time.Since(start).Seconds(),
+		metric.WithAttributes(attribute.String("rpc.method", method)))
+	rpcRequests.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("rpc.method", method),
+		attribute.String("rpc.status", status),
+	))
+
 	if err != nil {
 		return errors.Wrap(err, "handle")
 	}

--- a/internal/rpc/obs.go
+++ b/internal/rpc/obs.go
@@ -1,0 +1,26 @@
+package rpc
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/gotd/teled/internal/obs"
+)
+
+const instrumentationName = "github.com/gotd/teled/internal/rpc"
+
+var (
+	tracer = otel.Tracer(instrumentationName)
+	meter  = otel.Meter(instrumentationName)
+
+	// rpcRequests counts handled RPC requests, labeled by method and status.
+	rpcRequests = obs.Must(meter.Int64Counter("teled.rpc.requests",
+		metric.WithDescription("Total number of handled RPC requests."),
+		metric.WithUnit("{request}"),
+	))
+	// rpcDuration records RPC handler latency in seconds, labeled by method.
+	rpcDuration = obs.Must(meter.Float64Histogram("teled.rpc.duration",
+		metric.WithDescription("Duration of RPC request handling."),
+		metric.WithUnit("s"),
+	))
+)


### PR DESCRIPTION
## Context

Now that the server bootstraps through `go-faster/sdk` `app.Run` (#144), the global OpenTelemetry providers are available. This wires tracing and metrics through **every layer** of the server so a single request produces a nested trace from the wire down to storage.

> Stacked on #144 (`app.Run`). Base will be retargeted to `main` once #144 merges.

Instrumentation uses the **global** providers, so it is a no-op (negligible overhead) until an exporter is configured via `OTEL_*_EXPORTER` (documented in `init/teled.env`).

## Spans (nested per request)

```
mtproto.handle (SERVER, root — new trace per decrypted message)
└─ <rpc.method>            e.g. messages.sendMessage
   ├─ db.query SELECT      (pgx QueryTracer, CLIENT)
   ├─ db.query INSERT
   └─ objstore.put         (CLIENT)
```

- **mtproto** (`handle.go`): root span per decrypted message in `rpcHandle`. The MTProto protocol carries no inbound trace context, so each message starts a new trace; errors set `codes.Error`.
- **rpc** (`handler.go` `OnMessage`): one span per RPC, named by the method resolved from the request type id (`tg.TypesMap()`), so **all 36 handlers** are covered in one place. Records error status.
- **db** (`obs.go` + `open.go`): a `pgx.QueryTracer` opens a CLIENT span per SQL query (`db.system`, `db.operation`, `db.statement`) at the pool level — covers all 23 DB methods without per-call edits.
- **objstore** (`fs.go`): a span per filesystem op (`put`/`get`/`get_range`/`stat`/`delete`).

## Metrics

| Metric | Type | Labels |
|---|---|---|
| `teled.rpc.requests` | counter | method, status |
| `teled.rpc.duration` | histogram (s) | method |
| `teled.mtproto.connections.active` | up-down counter | — |
| `teled.mtproto.messages` | counter | — |
| `teled.db.query.duration` | histogram (s) | db.operation |
| `teled.objstore.duration` | histogram (s) | operation |

Instruments are built at init via a shared `internal/obs.Must` helper.

## Verification

```
go build ./... && go vet ./internal/...      # ok
golangci-lint run ./...                       # 0 issues
go test ./...                                 # all pass (db/rpc integration via testcontainers)
```

Added `internal/objstore/obs_test.go`, which installs an in-memory span recorder as the global provider and asserts `objstore.put/get/delete` spans are emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)