### PR TITLE
refactor(obs): thread OTEL providers explicitly instead of globals

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gotd/teled/internal/key"
 	"github.com/gotd/teled/internal/mtproto"
 	"github.com/gotd/teled/internal/objstore"
+	"github.com/gotd/teled/internal/obs"
 	"github.com/gotd/teled/internal/rpc"
 )
 
@@ -34,9 +35,12 @@ Based on https://gotd.dev Telegram protocol implementation.`,
 			// sets up telemetry and graceful shutdown. CLI subcommands (e.g.
 			// keys) run without it. app.Run terminates the process itself.
 			setTelemetryDefaults()
-			app.Run(func(ctx context.Context, lg *zap.Logger, _ *app.Telemetry) error {
+			app.Run(func(ctx context.Context, lg *zap.Logger, t *app.Telemetry) error {
 				a.lg = lg
-				return a.serve(ctx)
+				return a.serve(ctx, obs.Providers{
+					TracerProvider: t.TracerProvider(),
+					MeterProvider:  t.MeterProvider(),
+				})
 			})
 			return nil
 		},
@@ -62,8 +66,9 @@ Based on https://gotd.dev Telegram protocol implementation.`,
 	return rootCmd
 }
 
-// serve runs the Telegram server until ctx is canceled.
-func (a *application) serve(ctx context.Context) error {
+// serve runs the Telegram server until ctx is canceled. providers carries the
+// OpenTelemetry tracer and meter threaded into every layer.
+func (a *application) serve(ctx context.Context, providers obs.Providers) error {
 	privateKeyEncoded, err := os.ReadFile(a.PrivateKeyPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to read private key")
@@ -73,7 +78,7 @@ func (a *application) serve(ctx context.Context) error {
 		return errors.Wrap(err, "failed to parse private key")
 	}
 
-	keys, database, cleanup, err := a.setupStorage(ctx)
+	keys, database, cleanup, err := a.setupStorage(ctx, providers)
 	if err != nil {
 		return errors.Wrap(err, "setup storage")
 	}
@@ -84,22 +89,23 @@ func (a *application) serve(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to listen")
 	}
-	store, err := objstore.NewFS(a.ObjectStoreDir)
+	store, err := objstore.NewFS(a.ObjectStoreDir, providers)
 	if err != nil {
 		return errors.Wrap(err, "object store")
 	}
 
 	const dc = 1
 	opt := mtproto.ServerOptions{
-		DC:     dc,
-		Logger: a.lg,
-		Keys:   keys,
+		DC:        dc,
+		Logger:    a.lg,
+		Keys:      keys,
+		Providers: providers,
 	}
 	a.lg.Info("Listening",
 		zap.String("addr", a.Addr()),
 		zap.Int("dc", opt.DC),
 	)
-	handler := rpc.New(a.lg, database, store, dc, a.Host, a.Port)
+	handler := rpc.New(a.lg, database, store, dc, a.Host, a.Port, providers)
 	srv := mtproto.NewServer(mtproto.NewPrivateKey(k), mtproto.UnpackInvoke(handler), opt)
 	return srv.Serve(ctx, transport.Listen(transport.ObfuscatedListener(ln)))
 }

--- a/internal/cmd/storage.go
+++ b/internal/cmd/storage.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/gotd/teled/internal/db"
 	"github.com/gotd/teled/internal/mtproto"
+	"github.com/gotd/teled/internal/obs"
 	"github.com/gotd/teled/internal/queue"
 )
 
 // setupStorage initializes persistence and returns the auth-key store plus a
 // cleanup function. With no --postgres-uri it falls back to in-memory keys so
 // the server is runnable standalone (keys are then lost on restart).
-func (a *application) setupStorage(ctx context.Context) (mtproto.KeyStorage, *db.DB, func(), error) {
+func (a *application) setupStorage(ctx context.Context, providers obs.Providers) (mtproto.KeyStorage, *db.DB, func(), error) {
 	if a.PostgresURI == "" {
 		a.lg.Warn("No --postgres-uri set; auth keys are kept in memory and lost on restart")
 		return mtproto.NewInMemoryKeys(), nil, func() {}, nil
@@ -26,7 +27,7 @@ func (a *application) setupStorage(ctx context.Context) (mtproto.KeyStorage, *db
 		return nil, nil, nil, errors.Wrap(err, "migrate")
 	}
 
-	pool, err := db.Open(ctx, a.PostgresURI)
+	pool, err := db.Open(ctx, a.PostgresURI, providers)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "open database")
 	}

--- a/internal/db/main_test.go
+++ b/internal/db/main_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gotd/teled/internal/obs"
 	"github.com/gotd/teled/internal/pgtest"
 )
 
@@ -18,7 +19,7 @@ func newTestPool(t *testing.T) *pgxpool.Pool {
 	dsn := pgtest.New(t)
 	require.NoError(t, Migrate(dsn))
 
-	pool, err := Open(context.Background(), dsn)
+	pool, err := Open(context.Background(), dsn, obs.Providers{})
 	require.NoError(t, err)
 	t.Cleanup(pool.Close)
 

--- a/internal/db/obs.go
+++ b/internal/db/obs.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -17,23 +16,28 @@ import (
 
 const instrumentationName = "github.com/gotd/teled/internal/db"
 
-var (
-	tracer = otel.Tracer(instrumentationName)
-	meter  = otel.Meter(instrumentationName)
-
+// queryTracer implements pgx.QueryTracer to open a span and record metrics for
+// every query executed through the pool, covering all DB methods at once. It
+// carries the tracer and instruments built from the providers passed to Open.
+type queryTracer struct {
+	tracer trace.Tracer
 	// queryDuration records database query latency in seconds, labeled by the
 	// SQL operation (SELECT, INSERT, ...). A histogram also carries the count.
-	queryDuration = obs.Must(meter.Float64Histogram("teled.db.query.duration",
-		metric.WithDescription("Duration of database queries."),
-		metric.WithUnit("s"),
-	))
-)
-
-// queryTracer implements pgx.QueryTracer to open a span and record metrics for
-// every query executed through the pool, covering all DB methods at once.
-type queryTracer struct{}
+	queryDuration metric.Float64Histogram
+}
 
 var _ pgx.QueryTracer = queryTracer{}
+
+func newQueryTracer(p obs.Providers) queryTracer {
+	return queryTracer{
+		tracer: p.Tracer(instrumentationName),
+		queryDuration: obs.Must(p.Meter(instrumentationName).Float64Histogram(
+			"teled.db.query.duration",
+			metric.WithDescription("Duration of database queries."),
+			metric.WithUnit("s"),
+		)),
+	}
+}
 
 type queryTraceKey struct{}
 
@@ -44,9 +48,9 @@ type queryTraceData struct {
 }
 
 // TraceQueryStart starts a client span for the query.
-func (queryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+func (t queryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
 	op := sqlOperation(data.SQL)
-	ctx, span := tracer.Start(ctx, "db.query "+op, trace.WithSpanKind(trace.SpanKindClient))
+	ctx, span := t.tracer.Start(ctx, "db.query "+op, trace.WithSpanKind(trace.SpanKindClient))
 	span.SetAttributes(
 		attribute.String("db.system", "postgresql"),
 		attribute.String("db.operation", op),
@@ -56,7 +60,7 @@ func (queryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.Tr
 }
 
 // TraceQueryEnd ends the span and records the query duration metric.
-func (queryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+func (t queryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
 	d, ok := ctx.Value(queryTraceKey{}).(*queryTraceData)
 	if !ok {
 		return
@@ -66,7 +70,7 @@ func (queryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.Trac
 		d.span.SetStatus(codes.Error, data.Err.Error())
 	}
 	d.span.End()
-	queryDuration.Record(ctx, time.Since(d.start).Seconds(),
+	t.queryDuration.Record(ctx, time.Since(d.start).Seconds(),
 		metric.WithAttributes(attribute.String("db.operation", d.op)))
 }
 

--- a/internal/db/open.go
+++ b/internal/db/open.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/go-faster/errors"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gotd/teled/internal/obs"
 )
 
-// Open creates a new connection pool to the given PostgreSQL DSN.
-func Open(ctx context.Context, uri string) (*pgxpool.Pool, error) {
+// Open creates a new connection pool to the given PostgreSQL DSN. providers
+// supplies the OpenTelemetry tracer and meter used to instrument queries.
+func Open(ctx context.Context, uri string, providers obs.Providers) (*pgxpool.Pool, error) {
 	cfg, err := pgxpool.ParseConfig(uri)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse config")
@@ -19,7 +22,7 @@ func Open(ctx context.Context, uri string) (*pgxpool.Pool, error) {
 	cfg.MaxConnLifetime = 2 * time.Minute
 
 	// Trace every query and record query metrics.
-	cfg.ConnConfig.Tracer = queryTracer{}
+	cfg.ConnConfig.Tracer = newQueryTracer(providers)
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {

--- a/internal/mtproto/conn.go
+++ b/internal/mtproto/conn.go
@@ -36,9 +36,9 @@ func (s *Server) sendProtoError(ctx context.Context, conn transport.Conn, code i
 // serveConn serves a single client connection until it is closed.
 func (s *Server) serveConn(ctx context.Context, conn transport.Conn) error {
 	s.log.Debug("Client connected")
-	activeConns.Add(ctx, 1)
+	s.obs.activeConns.Add(ctx, 1)
 	defer func() {
-		activeConns.Add(ctx, -1)
+		s.obs.activeConns.Add(ctx, -1)
 		s.registry.removeConn(conn)
 		_ = conn.Close()
 		s.log.Debug("Client disconnected")

--- a/internal/mtproto/handle.go
+++ b/internal/mtproto/handle.go
@@ -22,7 +22,7 @@ import (
 // the root span for the request: there is no inbound trace context in the
 // MTProto protocol, so each encrypted message starts a new trace.
 func (s *Server) rpcHandle(ctx context.Context, c transport.Conn, b *bin.Buffer) (rerr error) {
-	ctx, span := tracer.Start(ctx, "mtproto.handle", trace.WithSpanKind(trace.SpanKindServer))
+	ctx, span := s.obs.tracer.Start(ctx, "mtproto.handle", trace.WithSpanKind(trace.SpanKindServer))
 	defer func() {
 		if rerr != nil {
 			span.RecordError(rerr)
@@ -30,7 +30,7 @@ func (s *Server) rpcHandle(ctx context.Context, c transport.Conn, b *bin.Buffer)
 		}
 		span.End()
 	}()
-	messages.Add(ctx, 1)
+	s.obs.messages.Add(ctx, 1)
 
 	m := &crypto.EncryptedMessage{}
 	if err := m.DecodeWithoutCopy(b); err != nil {

--- a/internal/mtproto/obs.go
+++ b/internal/mtproto/obs.go
@@ -1,26 +1,35 @@
 package mtproto
 
 import (
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/gotd/teled/internal/obs"
 )
 
 const instrumentationName = "github.com/gotd/teled/internal/mtproto"
 
-var (
-	tracer = otel.Tracer(instrumentationName)
-	meter  = otel.Meter(instrumentationName)
-
+// observability holds the tracer and metric instruments for the MTProto layer,
+// built from the providers passed via ServerOptions.
+type observability struct {
+	tracer trace.Tracer
 	// activeConns tracks the number of currently connected clients.
-	activeConns = obs.Must(meter.Int64UpDownCounter("teled.mtproto.connections.active",
-		metric.WithDescription("Number of active client connections."),
-		metric.WithUnit("{connection}"),
-	))
+	activeConns metric.Int64UpDownCounter
 	// messages counts decrypted MTProto messages handled by the server.
-	messages = obs.Must(meter.Int64Counter("teled.mtproto.messages",
-		metric.WithDescription("Number of decrypted MTProto messages handled."),
-		metric.WithUnit("{message}"),
-	))
-)
+	messages metric.Int64Counter
+}
+
+func newObservability(p obs.Providers) observability {
+	m := p.Meter(instrumentationName)
+	return observability{
+		tracer: p.Tracer(instrumentationName),
+		activeConns: obs.Must(m.Int64UpDownCounter("teled.mtproto.connections.active",
+			metric.WithDescription("Number of active client connections."),
+			metric.WithUnit("{connection}"),
+		)),
+		messages: obs.Must(m.Int64Counter("teled.mtproto.messages",
+			metric.WithDescription("Number of decrypted MTProto messages handled."),
+			metric.WithUnit("{message}"),
+		)),
+	}
+}

--- a/internal/mtproto/options.go
+++ b/internal/mtproto/options.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gotd/td/proto"
 	"github.com/gotd/td/tg"
 	"github.com/gotd/td/tmap"
+
+	"github.com/gotd/teled/internal/obs"
 )
 
 // ServerOptions configures a Server.
@@ -35,6 +37,9 @@ type ServerOptions struct {
 	ReadTimeout time.Duration
 	// WriteTimeout is the connection write timeout.
 	WriteTimeout time.Duration
+	// Providers supplies the OpenTelemetry tracer and meter for this layer.
+	// The zero value yields no-op instrumentation.
+	Providers obs.Providers
 }
 
 func (opt *ServerOptions) setDefaults() {

--- a/internal/mtproto/server.go
+++ b/internal/mtproto/server.go
@@ -37,6 +37,7 @@ type Server struct {
 
 	types *tmap.Map
 	log   *zap.Logger
+	obs   observability
 }
 
 // NewPrivateKey creates a new private key from an RSA private key.
@@ -60,6 +61,7 @@ func NewServer(key exchange.PrivateKey, handler Handler, opts ServerOptions) *Se
 		registry:     newRegistry(opts.Keys),
 		types:        opts.Types,
 		log:          opts.Logger,
+		obs:          newObservability(opts.Providers),
 	}
 }
 

--- a/internal/objstore/fs.go
+++ b/internal/objstore/fs.go
@@ -12,22 +12,25 @@ import (
 	"github.com/go-faster/errors"
 
 	"github.com/gotd/teled"
+	"github.com/gotd/teled/internal/obs"
 )
 
 // FS is a local-filesystem ObjectStore. Objects are stored under a base
 // directory, sharded by the first bytes of the key to avoid huge directories.
 type FS struct {
 	base string
+	obs  observability
 }
 
 var _ teled.ObjectStore = (*FS)(nil)
 
 // NewFS creates an FS rooted at base, creating the directory if needed.
-func NewFS(base string) (*FS, error) {
+// providers supplies the OpenTelemetry tracer and meter for this layer.
+func NewFS(base string, providers obs.Providers) (*FS, error) {
 	if err := os.MkdirAll(base, 0o750); err != nil {
 		return nil, errors.Wrap(err, "mkdir base")
 	}
-	return &FS{base: base}, nil
+	return &FS{base: base, obs: newObservability(providers)}, nil
 }
 
 // path maps a key to its on-disk location, sharded as base/ab/cd/<key>.
@@ -40,7 +43,7 @@ func (s *FS) path(key string) string {
 
 // Put implements teled.ObjectStore. It writes atomically via a temp file.
 func (s *FS) Put(ctx context.Context, key string, r io.Reader, _ int64, _ teled.PutOptions) (rerr error) {
-	done := observe(ctx, "put")
+	done := s.observe(ctx, "put")
 	defer func() { done(rerr) }()
 
 	dst := s.path(key)
@@ -72,7 +75,7 @@ func (s *FS) Put(ctx context.Context, key string, r io.Reader, _ int64, _ teled.
 
 // Get implements teled.ObjectStore.
 func (s *FS) Get(ctx context.Context, key string) (_ io.ReadCloser, rerr error) {
-	done := observe(ctx, "get")
+	done := s.observe(ctx, "get")
 	defer func() { done(rerr) }()
 
 	f, err := os.Open(s.path(key))
@@ -84,7 +87,7 @@ func (s *FS) Get(ctx context.Context, key string) (_ io.ReadCloser, rerr error) 
 
 // GetRange implements teled.ObjectStore, returning length bytes from offset.
 func (s *FS) GetRange(ctx context.Context, key string, offset, length int64) (_ io.ReadCloser, rerr error) {
-	done := observe(ctx, "get_range")
+	done := s.observe(ctx, "get_range")
 	defer func() { done(rerr) }()
 
 	f, err := os.Open(s.path(key))
@@ -100,7 +103,7 @@ func (s *FS) GetRange(ctx context.Context, key string, offset, length int64) (_ 
 
 // Stat implements teled.ObjectStore.
 func (s *FS) Stat(ctx context.Context, key string) (_ teled.ObjectInfo, rerr error) {
-	done := observe(ctx, "stat")
+	done := s.observe(ctx, "stat")
 	defer func() { done(rerr) }()
 
 	fi, err := os.Stat(s.path(key))
@@ -112,7 +115,7 @@ func (s *FS) Stat(ctx context.Context, key string) (_ teled.ObjectInfo, rerr err
 
 // Delete implements teled.ObjectStore. A missing object is not an error.
 func (s *FS) Delete(ctx context.Context, key string) (rerr error) {
-	done := observe(ctx, "delete")
+	done := s.observe(ctx, "delete")
 	defer func() { done(rerr) }()
 
 	if err := os.Remove(s.path(key)); err != nil && !os.IsNotExist(err) {

--- a/internal/objstore/fs_test.go
+++ b/internal/objstore/fs_test.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/gotd/teled"
 	"github.com/gotd/teled/internal/objstore"
+	"github.com/gotd/teled/internal/obs"
 )
 
 func TestFS(t *testing.T) {
 	ctx := context.Background()
-	fs, err := objstore.NewFS(t.TempDir())
+	fs, err := objstore.NewFS(t.TempDir(), obs.Providers{})
 	require.NoError(t, err)
 
 	const key = "abcdef0123456789"

--- a/internal/objstore/obs.go
+++ b/internal/objstore/obs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -15,23 +14,31 @@ import (
 
 const instrumentationName = "github.com/gotd/teled/internal/objstore"
 
-var (
-	tracer = otel.Tracer(instrumentationName)
-	meter  = otel.Meter(instrumentationName)
-
+// observability holds the tracer and metric instruments for the object store,
+// built from the providers passed to NewFS.
+type observability struct {
+	tracer trace.Tracer
 	// opDuration records object store operation latency in seconds, labeled by
 	// operation (put, get, ...).
-	opDuration = obs.Must(meter.Float64Histogram("teled.objstore.duration",
-		metric.WithDescription("Duration of object store operations."),
-		metric.WithUnit("s"),
-	))
-)
+	opDuration metric.Float64Histogram
+}
+
+func newObservability(p obs.Providers) observability {
+	return observability{
+		tracer: p.Tracer(instrumentationName),
+		opDuration: obs.Must(p.Meter(instrumentationName).Float64Histogram(
+			"teled.objstore.duration",
+			metric.WithDescription("Duration of object store operations."),
+			metric.WithUnit("s"),
+		)),
+	}
+}
 
 // observe starts a span for an object store operation and returns a function
 // that ends it and records the operation duration. Pass the operation's error
 // to the returned function so failures are recorded on the span.
-func observe(ctx context.Context, op string) func(error) {
-	ctx, span := tracer.Start(ctx, "objstore."+op, trace.WithSpanKind(trace.SpanKindClient))
+func (s *FS) observe(ctx context.Context, op string) func(error) {
+	ctx, span := s.obs.tracer.Start(ctx, "objstore."+op, trace.WithSpanKind(trace.SpanKindClient))
 	span.SetAttributes(attribute.String("objstore.operation", op))
 	start := time.Now()
 	return func(err error) {
@@ -40,7 +47,7 @@ func observe(ctx context.Context, op string) func(error) {
 			span.SetStatus(codes.Error, err.Error())
 		}
 		span.End()
-		opDuration.Record(ctx, time.Since(start).Seconds(),
+		s.obs.opDuration.Record(ctx, time.Since(start).Seconds(),
 			metric.WithAttributes(attribute.String("objstore.operation", op)))
 	}
 }

--- a/internal/objstore/obs_test.go
+++ b/internal/objstore/obs_test.go
@@ -7,25 +7,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/gotd/teled"
 	"github.com/gotd/teled/internal/objstore"
+	"github.com/gotd/teled/internal/obs"
 )
 
 // TestFSTracing verifies that object store operations emit spans through the
-// global tracer provider.
+// tracer provider passed in via NewFS.
 func TestFSTracing(t *testing.T) {
 	sr := tracetest.NewSpanRecorder()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
-	prev := otel.GetTracerProvider()
-	otel.SetTracerProvider(tp)
-	t.Cleanup(func() { otel.SetTracerProvider(prev) })
 
 	ctx := context.Background()
-	fs, err := objstore.NewFS(t.TempDir())
+	fs, err := objstore.NewFS(t.TempDir(), obs.Providers{TracerProvider: tp})
 	require.NoError(t, err)
 
 	require.NoError(t, fs.Put(ctx, "abcd-key", bytes.NewBufferString("payload"), 7, teled.PutOptions{}))

--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -2,9 +2,42 @@
 // across teled's internal packages.
 package obs
 
+import (
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// Providers carries the OpenTelemetry providers threaded explicitly through the
+// application (from go-faster/sdk app.Run) instead of relying on the global
+// otel providers. The zero value is valid and yields no-op instrumentation.
+type Providers struct {
+	TracerProvider trace.TracerProvider
+	MeterProvider  metric.MeterProvider
+}
+
+// Tracer returns a named tracer, falling back to a no-op provider when unset.
+func (p Providers) Tracer(name string) trace.Tracer {
+	tp := p.TracerProvider
+	if tp == nil {
+		tp = tracenoop.NewTracerProvider()
+	}
+	return tp.Tracer(name)
+}
+
+// Meter returns a named meter, falling back to a no-op provider when unset.
+func (p Providers) Meter(name string) metric.Meter {
+	mp := p.MeterProvider
+	if mp == nil {
+		mp = metricnoop.NewMeterProvider()
+	}
+	return mp.Meter(name)
+}
+
 // Must panics if err is non-nil, otherwise returns v. It is meant for
-// constructing OpenTelemetry instruments at package init, where an error means
-// a programming mistake (e.g. an invalid instrument name).
+// constructing OpenTelemetry instruments, where an error means a programming
+// mistake (e.g. an invalid instrument name).
 func Must[T any](v T, err error) T {
 	if err != nil {
 		panic(err)

--- a/internal/rpc/dm_e2e_test.go
+++ b/internal/rpc/dm_e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gotd/teled/internal/db"
 	"github.com/gotd/teled/internal/mtproto"
 	"github.com/gotd/teled/internal/objstore"
+	"github.com/gotd/teled/internal/obs"
 	"github.com/gotd/teled/internal/pgtest"
 )
 
@@ -41,7 +42,7 @@ func newTestEnv(t *testing.T, ctx context.Context, g *tdsync.CancellableGroup) *
 
 	dsn := pgtest.New(t)
 	require.NoError(t, db.Migrate(dsn))
-	pool, err := db.Open(ctx, dsn)
+	pool, err := db.Open(ctx, dsn, obs.Providers{})
 	require.NoError(t, err)
 	t.Cleanup(pool.Close)
 	database := db.New(pool)
@@ -52,9 +53,9 @@ func newTestEnv(t *testing.T, ctx context.Context, g *tdsync.CancellableGroup) *
 	require.NoError(t, err)
 	addr := ln.Addr().(*net.TCPAddr)
 
-	store, err := objstore.NewFS(t.TempDir())
+	store, err := objstore.NewFS(t.TempDir(), obs.Providers{})
 	require.NoError(t, err)
-	handler := New(log.Named("rpc"), database, store, dcID, addr.IP.String(), addr.Port)
+	handler := New(log.Named("rpc"), database, store, dcID, addr.IP.String(), addr.Port, obs.Providers{})
 	srv := mtproto.NewServer(mtproto.NewPrivateKey(rsaKey), mtproto.UnpackInvoke(handler), mtproto.ServerOptions{
 		DC:     dcID,
 		Keys:   db.NewKeyStore(pool),

--- a/internal/rpc/handler.go
+++ b/internal/rpc/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gotd/teled"
 	"github.com/gotd/teled/internal/db"
 	"github.com/gotd/teled/internal/mtproto"
+	"github.com/gotd/teled/internal/obs"
 )
 
 // Handler owns the server dispatcher and backs RPCs with storage.
@@ -32,14 +33,18 @@ type Handler struct {
 	sessions   *sessionRegistry
 	staging    *uploadStaging
 	dispatcher *tg.ServerDispatcher
+
+	obs observability
 }
 
 // New builds a Handler and registers all supported RPCs. database and store may
-// be nil, in which case the corresponding RPCs return an error.
-func New(lg *zap.Logger, database *db.DB, store teled.ObjectStore, dc int, host string, port int) *Handler {
+// be nil, in which case the corresponding RPCs return an error. providers
+// supplies the OpenTelemetry tracer and meter for this layer.
+func New(lg *zap.Logger, database *db.DB, store teled.ObjectStore, dc int, host string, port int, providers obs.Providers) *Handler {
 	h := &Handler{
 		lg: lg, db: database, store: store, dc: dc, host: host, port: port,
 		sessions: newSessionRegistry(), staging: newUploadStaging(),
+		obs: newObservability(providers),
 	}
 	d := tg.NewServerDispatcher(h.fallback)
 	h.register(d)
@@ -63,7 +68,7 @@ func (h *Handler) OnMessage(server *mtproto.Server, req *mtproto.Request) error 
 		}
 	}
 
-	ctx, span := tracer.Start(ctx, method)
+	ctx, span := h.obs.tracer.Start(ctx, method)
 	defer span.End()
 	start := time.Now()
 
@@ -82,9 +87,9 @@ func (h *Handler) OnMessage(server *mtproto.Server, req *mtproto.Request) error 
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 	}
-	rpcDuration.Record(ctx, time.Since(start).Seconds(),
+	h.obs.duration.Record(ctx, time.Since(start).Seconds(),
 		metric.WithAttributes(attribute.String("rpc.method", method)))
-	rpcRequests.Add(ctx, 1, metric.WithAttributes(
+	h.obs.requests.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("rpc.method", method),
 		attribute.String("rpc.status", status),
 	))

--- a/internal/rpc/obs.go
+++ b/internal/rpc/obs.go
@@ -1,26 +1,35 @@
 package rpc
 
 import (
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/gotd/teled/internal/obs"
 )
 
 const instrumentationName = "github.com/gotd/teled/internal/rpc"
 
-var (
-	tracer = otel.Tracer(instrumentationName)
-	meter  = otel.Meter(instrumentationName)
+// observability holds the tracer and metric instruments for the RPC layer,
+// built from the providers threaded in via New.
+type observability struct {
+	tracer trace.Tracer
+	// requests counts handled RPC requests, labeled by method and status.
+	requests metric.Int64Counter
+	// duration records RPC handler latency in seconds, labeled by method.
+	duration metric.Float64Histogram
+}
 
-	// rpcRequests counts handled RPC requests, labeled by method and status.
-	rpcRequests = obs.Must(meter.Int64Counter("teled.rpc.requests",
-		metric.WithDescription("Total number of handled RPC requests."),
-		metric.WithUnit("{request}"),
-	))
-	// rpcDuration records RPC handler latency in seconds, labeled by method.
-	rpcDuration = obs.Must(meter.Float64Histogram("teled.rpc.duration",
-		metric.WithDescription("Duration of RPC request handling."),
-		metric.WithUnit("s"),
-	))
-)
+func newObservability(p obs.Providers) observability {
+	m := p.Meter(instrumentationName)
+	return observability{
+		tracer: p.Tracer(instrumentationName),
+		requests: obs.Must(m.Int64Counter("teled.rpc.requests",
+			metric.WithDescription("Total number of handled RPC requests."),
+			metric.WithUnit("{request}"),
+		)),
+		duration: obs.Must(m.Float64Histogram("teled.rpc.duration",
+			metric.WithDescription("Duration of RPC request handling."),
+			metric.WithUnit("s"),
+		)),
+	}
+}

--- a/internal/rpc/rpc_e2e_test.go
+++ b/internal/rpc/rpc_e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gotd/teled/internal/db"
 	"github.com/gotd/teled/internal/mtproto"
 	"github.com/gotd/teled/internal/objstore"
+	"github.com/gotd/teled/internal/obs"
 	"github.com/gotd/teled/internal/pgtest"
 )
 
@@ -40,7 +41,7 @@ func TestAuthSignUpAndSelf(t *testing.T) {
 
 	dsn := pgtest.New(t)
 	require.NoError(t, db.Migrate(dsn))
-	pool, err := db.Open(ctx, dsn)
+	pool, err := db.Open(ctx, dsn, obs.Providers{})
 	require.NoError(t, err)
 	t.Cleanup(pool.Close)
 	database := db.New(pool)
@@ -51,9 +52,9 @@ func TestAuthSignUpAndSelf(t *testing.T) {
 	require.NoError(t, err)
 	addr := ln.Addr().(*net.TCPAddr)
 
-	store, err := objstore.NewFS(t.TempDir())
+	store, err := objstore.NewFS(t.TempDir(), obs.Providers{})
 	require.NoError(t, err)
-	handler := New(log.Named("rpc"), database, store, dcID, addr.IP.String(), addr.Port)
+	handler := New(log.Named("rpc"), database, store, dcID, addr.IP.String(), addr.Port, obs.Providers{})
 	srv := mtproto.NewServer(mtproto.NewPrivateKey(rsaKey), mtproto.UnpackInvoke(handler), mtproto.ServerOptions{
 		DC:     dcID,
 		Keys:   db.NewKeyStore(pool), // Persisted: sessions.key_id FK -> auth_keys.


### PR DESCRIPTION
## Context

The tracing/metrics instrumentation from #145 read the **global** otel tracer/meter providers. This reworks it to thread the providers from `go-faster/sdk` `app.Run` **explicitly** through every layer, so nothing depends on the otel globals being set.

## Changes

- `internal/obs` gains a `Providers` bundle (`TracerProvider` + `MeterProvider`) with a **no-op fallback** when unset, plus `Tracer(name)` / `Meter(name)` helpers. The zero value is valid → tests and library use need no telemetry setup.
- `serve` builds `obs.Providers` from `*app.Telemetry` (`t.TracerProvider()`, `t.MeterProvider()`) and passes it into `db.Open`, `objstore.NewFS`, `rpc.New` and `mtproto.ServerOptions`.
- Each layer's tracer + instruments are now built in its **constructor** from the passed providers and stored on the struct (`Handler.obs`, `Server.obs`, `FS.obs`, `queryTracer`), replacing the package-level vars previously bound to `otel.Tracer`/`otel.Meter`.

No behavioural change when telemetry is enabled — the spans and metrics are identical. The only difference is the provider source.

## Verification

```
grep -rn 'otel\.\(Tracer\|Meter\|Get.*Provider\)' internal/   # no matches
go build ./... && go vet ./...                                  # ok
golangci-lint run ./...                                          # 0 issues
go test ./...                                                    # all pass
```

`internal/objstore/obs_test.go` now passes its `TracerProvider` in via `NewFS` (rather than installing a global) and still asserts `objstore.put/get/delete` spans are emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)