### PR TITLE
feat(rpc): bot login, identity and command management

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -1,0 +1,7 @@
+package teled
+
+// BotCommand is one entry in a bot's published command list.
+type BotCommand struct {
+	Command     string `json:"command"`
+	Description string `json:"description"`
+}

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -54,8 +54,29 @@ MTProto session ↔ logged-in user binding.
 | last_name   | TEXT        | NOT NULL DEFAULT ''                  |
 | about       | TEXT        | NOT NULL DEFAULT ''                  |
 | is_bot      | BOOLEAN     | NOT NULL DEFAULT FALSE               |
+| bot_token   | TEXT        | UNIQUE (set for bot accounts)        |
 | photo_file_id | BIGINT    | FK → files(id)                       |
 | created_at  | TIMESTAMPTZ | NOT NULL DEFAULT now()               |
+
+Bots log in with `auth.importBotAuthorization`: the first login with a
+well-formed `<id>:<secret>` token auto-provisions a `is_bot` account holding
+that `bot_token`, and later logins reuse it.
+
+## bot_commands
+
+A bot's published command list, per scope and language. `scope` is the
+hex-encoded MTProto `BotCommandScope` so every scope variant (including
+peer-specific ones) maps to a distinct row.
+
+| Column      | Type    | Constraints                                      |
+|-------------|---------|--------------------------------------------------|
+| bot_user_id | BIGINT  | NOT NULL, PK, FK → users(id) ON DELETE CASCADE   |
+| scope       | TEXT    | NOT NULL, PK                                     |
+| lang_code   | TEXT    | NOT NULL DEFAULT '', PK                          |
+| commands    | JSONB   | NOT NULL DEFAULT '[]' ([{command, description}]) |
+
+Managed by `bots.setBotCommands` / `bots.getBotCommands` /
+`bots.resetBotCommands`.
 
 ## phone_codes
 

--- a/internal/db/_migrations/000007_bots.down.sql
+++ b/internal/db/_migrations/000007_bots.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE bot_commands;
+
+ALTER TABLE users
+    DROP COLUMN bot_token,
+    DROP COLUMN is_bot;

--- a/internal/db/_migrations/000007_bots.up.sql
+++ b/internal/db/_migrations/000007_bots.up.sql
@@ -1,0 +1,18 @@
+-- Bot accounts: marked by is_bot and authenticated by an opaque bot_token
+-- instead of a phone number.
+ALTER TABLE users
+    ADD COLUMN is_bot    BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN bot_token TEXT    UNIQUE;
+
+-- bot_commands stores a bot's published command list per (scope, language).
+-- scope is the hex-encoded MTProto BotCommandScope so every scope variant,
+-- including peer-specific ones, maps to a distinct row. commands is the
+-- ordered list as JSON ([{command, description}, ...]).
+CREATE TABLE bot_commands
+(
+    bot_user_id BIGINT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    scope       TEXT   NOT NULL,
+    lang_code   TEXT   NOT NULL DEFAULT '',
+    commands    JSONB  NOT NULL DEFAULT '[]'::jsonb,
+    PRIMARY KEY (bot_user_id, scope, lang_code)
+);

--- a/internal/db/bots.go
+++ b/internal/db/bots.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	gerrors "github.com/go-faster/errors"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gotd/teled"
+)
+
+// SetBotCommands replaces the command list a bot publishes for the given scope
+// and language. An empty commands slice stores an empty list (distinct from
+// having no row, which ResetBotCommands produces).
+func (db *DB) SetBotCommands(ctx context.Context, botUserID int64, scope, langCode string, commands []teled.BotCommand) error {
+	if commands == nil {
+		commands = []teled.BotCommand{}
+	}
+	payload, err := json.Marshal(commands)
+	if err != nil {
+		return gerrors.Wrap(err, "marshal commands")
+	}
+
+	q := psql.Insert("bot_commands").
+		Columns("bot_user_id", "scope", "lang_code", "commands").
+		Values(botUserID, scope, langCode, payload).
+		Suffix("ON CONFLICT (bot_user_id, scope, lang_code) DO UPDATE SET commands = EXCLUDED.commands")
+
+	sql, args, err := q.ToSql()
+	if err != nil {
+		return gerrors.Wrap(err, "build query")
+	}
+	if _, err := db.pool.Exec(ctx, sql, args...); err != nil {
+		return gerrors.Wrap(err, "exec")
+	}
+	return nil
+}
+
+// BotCommands returns the command list published for the given scope and
+// language. A missing row yields an empty slice and no error.
+func (db *DB) BotCommands(ctx context.Context, botUserID int64, scope, langCode string) ([]teled.BotCommand, error) {
+	q := psql.Select("commands").From("bot_commands").
+		Where("bot_user_id = ? AND scope = ? AND lang_code = ?", botUserID, scope, langCode)
+
+	sql, args, err := q.ToSql()
+	if err != nil {
+		return nil, gerrors.Wrap(err, "build query")
+	}
+
+	var payload []byte
+	if err := db.pool.QueryRow(ctx, sql, args...).Scan(&payload); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, gerrors.Wrap(err, "scan")
+	}
+
+	var commands []teled.BotCommand
+	if err := json.Unmarshal(payload, &commands); err != nil {
+		return nil, gerrors.Wrap(err, "unmarshal commands")
+	}
+	return commands, nil
+}
+
+// ResetBotCommands removes the command list for the given scope and language,
+// restoring the bot's default (empty) commands there.
+func (db *DB) ResetBotCommands(ctx context.Context, botUserID int64, scope, langCode string) error {
+	q := psql.Delete("bot_commands").
+		Where("bot_user_id = ? AND scope = ? AND lang_code = ?", botUserID, scope, langCode)
+
+	sql, args, err := q.ToSql()
+	if err != nil {
+		return gerrors.Wrap(err, "build query")
+	}
+	if _, err := db.pool.Exec(ctx, sql, args...); err != nil {
+		return gerrors.Wrap(err, "exec")
+	}
+	return nil
+}

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -24,13 +24,14 @@ var userColumns = []string{
 	"first_name",
 	"last_name",
 	"about",
+	"is_bot",
 	"created_at",
 }
 
 func scanUser(row pgx.Row, u *teled.User) error {
 	return row.Scan(
 		&u.ID, &u.AccessHash, &u.Phone, &u.Username,
-		&u.FirstName, &u.LastName, &u.About, &u.CreatedAt,
+		&u.FirstName, &u.LastName, &u.About, &u.IsBot, &u.CreatedAt,
 	)
 }
 
@@ -62,6 +63,37 @@ func (db *DB) CreateUser(ctx context.Context, phone, firstName, lastName string)
 		return teled.User{}, gerrors.Wrap(err, "insert")
 	}
 	return u, nil
+}
+
+// CreateBot inserts a new bot account authenticated by token. username may be
+// empty.
+func (db *DB) CreateBot(ctx context.Context, token, username, firstName string) (teled.User, error) {
+	cols := []string{"access_hash", "bot_token", "first_name", "is_bot"}
+	vals := []any{genAccessHash(), token, firstName, true}
+	if username != "" {
+		cols = append(cols, "username")
+		vals = append(vals, username)
+	}
+	q := psql.Insert("users").
+		Columns(cols...).
+		Values(vals...).
+		Suffix("RETURNING " + strings.Join(userColumns, ", "))
+
+	sql, args, err := q.ToSql()
+	if err != nil {
+		return teled.User{}, gerrors.Wrap(err, "build query")
+	}
+
+	var u teled.User
+	if err := scanUser(db.pool.QueryRow(ctx, sql, args...), &u); err != nil {
+		return teled.User{}, gerrors.Wrap(err, "insert")
+	}
+	return u, nil
+}
+
+// BotByToken returns the bot account holding token, if any.
+func (db *DB) BotByToken(ctx context.Context, token string) (*teled.User, bool, error) {
+	return db.userBy(ctx, "bot_token = ?", token)
 }
 
 func (db *DB) userBy(ctx context.Context, where string, arg any) (*teled.User, bool, error) {

--- a/internal/rpc/auth.go
+++ b/internal/rpc/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"strings"
 	"time"
 
 	"github.com/gotd/td/tg"
@@ -104,6 +105,41 @@ func (h *Handler) authSignUp(ctx context.Context, req *tg.AuthSignUpRequest) (tg
 		return nil, h.internal("bind session", err)
 	}
 	return &tg.AuthAuthorization{User: toTGUser(u, true)}, nil
+}
+
+// authImportBotAuthorization logs in a bot by token. Tokens are not minted by a
+// BotFather here: the first login with a well-formed token auto-provisions the
+// bot account, and subsequent logins reuse it. This mirrors how authSignUp
+// auto-creates user accounts for the test server.
+func (h *Handler) authImportBotAuthorization(
+	ctx context.Context, req *tg.AuthImportBotAuthorizationRequest,
+) (tg.AuthAuthorizationClass, error) {
+	if err := h.requireDB(); err != nil {
+		return nil, err
+	}
+
+	// A valid bot token is "<bot_id>:<secret>"; reject anything else.
+	id, secret, ok := strings.Cut(req.BotAuthToken, ":")
+	if !ok || id == "" || secret == "" {
+		return nil, tgerr.New(400, "ACCESS_TOKEN_INVALID")
+	}
+
+	bot, found, err := h.db.BotByToken(ctx, req.BotAuthToken)
+	if err != nil {
+		return nil, h.internal("lookup bot", err)
+	}
+	if !found {
+		created, err := h.db.CreateBot(ctx, req.BotAuthToken, "", "Bot "+id)
+		if err != nil {
+			return nil, h.internal("create bot", err)
+		}
+		bot = &created
+	}
+
+	if err := h.bindCaller(ctx, bot.ID); err != nil {
+		return nil, h.internal("bind session", err)
+	}
+	return &tg.AuthAuthorization{User: toTGUser(*bot, true)}, nil
 }
 
 // authLogOut unbinds the session's user.

--- a/internal/rpc/bots.go
+++ b/internal/rpc/bots.go
@@ -1,0 +1,90 @@
+package rpc
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgerr"
+
+	"github.com/gotd/teled"
+)
+
+// requireBot resolves the caller and asserts it is a bot account, returning
+// USER_BOT_REQUIRED otherwise. Bot command management is bot-only.
+func (h *Handler) requireBot(ctx context.Context) (teled.User, error) {
+	caller, err := h.requireCaller(ctx)
+	if err != nil {
+		return teled.User{}, err
+	}
+	if !caller.IsBot {
+		return teled.User{}, tgerr.New(400, "USER_BOT_REQUIRED")
+	}
+	return caller, nil
+}
+
+// scopeKey serializes a BotCommandScope to a stable, lossless key by encoding
+// its MTProto representation. This keeps peer-specific scopes distinct from one
+// another and from the global scopes. A nil scope keys as the default scope.
+func scopeKey(scope tg.BotCommandScopeClass) string {
+	if scope == nil {
+		scope = &tg.BotCommandScopeDefault{}
+	}
+	var b bin.Buffer
+	if err := scope.Encode(&b); err != nil {
+		// Encoding a scope cannot realistically fail; fall back to the type id.
+		return scope.TypeName()
+	}
+	return hex.EncodeToString(b.Buf)
+}
+
+// botsSetBotCommands stores the caller bot's command list for a scope/language.
+func (h *Handler) botsSetBotCommands(ctx context.Context, req *tg.BotsSetBotCommandsRequest) (bool, error) {
+	bot, err := h.requireBot(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	commands := make([]teled.BotCommand, len(req.Commands))
+	for i, c := range req.Commands {
+		commands[i] = teled.BotCommand{Command: c.Command, Description: c.Description}
+	}
+
+	if err := h.db.SetBotCommands(ctx, bot.ID, scopeKey(req.Scope), req.LangCode, commands); err != nil {
+		return false, h.internal("set bot commands", err)
+	}
+	return true, nil
+}
+
+// botsGetBotCommands returns the caller bot's command list for a scope/language.
+func (h *Handler) botsGetBotCommands(ctx context.Context, req *tg.BotsGetBotCommandsRequest) ([]tg.BotCommand, error) {
+	bot, err := h.requireBot(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	commands, err := h.db.BotCommands(ctx, bot.ID, scopeKey(req.Scope), req.LangCode)
+	if err != nil {
+		return nil, h.internal("get bot commands", err)
+	}
+
+	out := make([]tg.BotCommand, len(commands))
+	for i, c := range commands {
+		out[i] = tg.BotCommand{Command: c.Command, Description: c.Description}
+	}
+	return out, nil
+}
+
+// botsResetBotCommands clears the caller bot's command list for a scope/language.
+func (h *Handler) botsResetBotCommands(ctx context.Context, req *tg.BotsResetBotCommandsRequest) (bool, error) {
+	bot, err := h.requireBot(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if err := h.db.ResetBotCommands(ctx, bot.ID, scopeKey(req.Scope), req.LangCode); err != nil {
+		return false, h.internal("reset bot commands", err)
+	}
+	return true, nil
+}

--- a/internal/rpc/bots_e2e_test.go
+++ b/internal/rpc/bots_e2e_test.go
@@ -1,0 +1,141 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/session"
+	"github.com/gotd/td/tdsync"
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgerr"
+)
+
+// importBot logs in a bot by token and returns the resolved self user.
+func importBot(ctx context.Context, t *testing.T, api *tg.Client, token string) *tg.User {
+	t.Helper()
+	authResp, err := api.AuthImportBotAuthorization(ctx, &tg.AuthImportBotAuthorizationRequest{
+		APIID: telegram.TestAppID, APIHash: telegram.TestAppHash, BotAuthToken: token,
+	})
+	require.NoError(t, err)
+	return authResp.(*tg.AuthAuthorization).User.(*tg.User)
+}
+
+// TestBotImportAuthorizationAndCommands covers the bot lifecycle: token login
+// (auto-provisioning then reuse), self-resolution carrying the Bot flag, and
+// the set/get/reset bot command round trip.
+func TestBotImportAuthorizationAndCommands(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	g := tdsync.NewCancellableGroup(ctx)
+	env := newTestEnv(t, ctx, g)
+
+	const token = "424242:secret-bot-token"
+	storage := &session.StorageMemory{}
+	var botID int64
+
+	env.runClient(ctx, t, storage, func(api *tg.Client) {
+		self := importBot(ctx, t, api, token)
+		require.True(t, self.Self)
+		require.True(t, self.Bot)
+		require.NotZero(t, self.ID)
+		botID = self.ID
+
+		// users.getUsers(self) preserves the bot flag.
+		users, err := api.UsersGetUsers(ctx, []tg.InputUserClass{&tg.InputUserSelf{}})
+		require.NoError(t, err)
+		require.Len(t, users, 1)
+		require.True(t, users[0].(*tg.User).Bot)
+
+		// No commands published yet.
+		cmds, err := api.BotsGetBotCommands(ctx, &tg.BotsGetBotCommandsRequest{Scope: &tg.BotCommandScopeDefault{}})
+		require.NoError(t, err)
+		require.Empty(t, cmds)
+
+		// Publish, then read back in order.
+		want := []tg.BotCommand{
+			{Command: "start", Description: "Start the bot"},
+			{Command: "help", Description: "Show help"},
+		}
+		ok, err := api.BotsSetBotCommands(ctx, &tg.BotsSetBotCommandsRequest{
+			Scope: &tg.BotCommandScopeDefault{}, Commands: want,
+		})
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		cmds, err = api.BotsGetBotCommands(ctx, &tg.BotsGetBotCommandsRequest{Scope: &tg.BotCommandScopeDefault{}})
+		require.NoError(t, err)
+		require.Equal(t, want, cmds)
+
+		// A different scope is independent and still empty.
+		usersScope, err := api.BotsGetBotCommands(ctx, &tg.BotsGetBotCommandsRequest{Scope: &tg.BotCommandScopeUsers{}})
+		require.NoError(t, err)
+		require.Empty(t, usersScope)
+
+		// Reset clears the default scope.
+		ok, err = api.BotsResetBotCommands(ctx, &tg.BotsResetBotCommandsRequest{Scope: &tg.BotCommandScopeDefault{}})
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		cmds, err = api.BotsGetBotCommands(ctx, &tg.BotsGetBotCommandsRequest{Scope: &tg.BotCommandScopeDefault{}})
+		require.NoError(t, err)
+		require.Empty(t, cmds)
+	})
+
+	// Re-login with the same token reuses the account (no new bot).
+	env.runClient(ctx, t, &session.StorageMemory{}, func(api *tg.Client) {
+		self := importBot(ctx, t, api, token)
+		require.Equal(t, botID, self.ID)
+	})
+
+	g.Cancel()
+	if err := g.Wait(); err != nil {
+		require.ErrorIs(t, err, context.Canceled)
+	}
+}
+
+// TestBotImportAuthorizationInvalidToken rejects a token without the
+// "<id>:<secret>" shape.
+func TestBotImportAuthorizationInvalidToken(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	g := tdsync.NewCancellableGroup(ctx)
+	env := newTestEnv(t, ctx, g)
+
+	env.runClient(ctx, t, &session.StorageMemory{}, func(api *tg.Client) {
+		_, err := api.AuthImportBotAuthorization(ctx, &tg.AuthImportBotAuthorizationRequest{
+			APIID: telegram.TestAppID, APIHash: telegram.TestAppHash, BotAuthToken: "not-a-valid-token",
+		})
+		require.True(t, tgerr.Is(err, "ACCESS_TOKEN_INVALID"))
+	})
+
+	g.Cancel()
+	if err := g.Wait(); err != nil {
+		require.ErrorIs(t, err, context.Canceled)
+	}
+}
+
+// TestBotCommandsRequireBot rejects bot command management from a human account.
+func TestBotCommandsRequireBot(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	g := tdsync.NewCancellableGroup(ctx)
+	env := newTestEnv(t, ctx, g)
+
+	env.runClient(ctx, t, &session.StorageMemory{}, func(api *tg.Client) {
+		signUp(ctx, t, api, "+3333333333", "Carol")
+		_, err := api.BotsSetBotCommands(ctx, &tg.BotsSetBotCommandsRequest{
+			Scope:    &tg.BotCommandScopeDefault{},
+			Commands: []tg.BotCommand{{Command: "start", Description: "x"}},
+		})
+		require.True(t, tgerr.Is(err, "USER_BOT_REQUIRED"))
+	})
+
+	g.Cancel()
+	if err := g.Wait(); err != nil {
+		require.ErrorIs(t, err, context.Canceled)
+	}
+}

--- a/internal/rpc/convert.go
+++ b/internal/rpc/convert.go
@@ -28,6 +28,10 @@ func toTGUser(u teled.User, self bool) *tg.User {
 	if u.Phone != "" {
 		user.Phone = u.Phone
 	}
+	if u.IsBot {
+		user.Bot = true
+		user.BotInfoVersion = 1
+	}
 	user.SetFlags()
 	return user
 }

--- a/internal/rpc/register.go
+++ b/internal/rpc/register.go
@@ -22,6 +22,12 @@ func (h *Handler) register(d *tg.ServerDispatcher) {
 	d.OnAuthLogOut(h.authLogOut)
 	d.OnAuthExportLoginToken(h.authExportLoginToken)
 	d.OnAuthBindTempAuthKey(h.authBindTempAuthKey)
+	d.OnAuthImportBotAuthorization(h.authImportBotAuthorization)
+
+	// Bots.
+	d.OnBotsSetBotCommands(h.botsSetBotCommands)
+	d.OnBotsGetBotCommands(h.botsGetBotCommands)
+	d.OnBotsResetBotCommands(h.botsResetBotCommands)
 
 	// Users (M2, storage-backed).
 	d.OnUsersGetUsers(h.usersGetUsers)

--- a/users.go
+++ b/users.go
@@ -11,5 +11,6 @@ type User struct {
 	FirstName  string
 	LastName   string
 	About      string
+	IsBot      bool // true for bot accounts authenticated by token
 	CreatedAt  time.Time
 }


### PR DESCRIPTION
Add bot support to the test server: bots authenticate with auth.importBotAuthorization by token (first login auto-provisions the account, later logins reuse it), carry the Bot flag through user wire forms, and manage their published command list via bots.setBotCommands/getBotCommands/resetBotCommands.

Storage-backed by a new is_bot/bot_token on users and a bot_commands table keyed by hex-encoded scope and language. Covered by real-client e2e tests.