### PR TITLE
Bots support: login, commands, BotFather, and embeddable server

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -5,3 +5,20 @@ type BotCommand struct {
 	Command     string `json:"command"`
 	Description string `json:"description"`
 }
+
+// BotFatherID is the fixed user id of the built-in BotFather account. It
+// mirrors real Telegram's BotFather id and is seeded by migration.
+const BotFatherID int64 = 93372553
+
+// BotFather conversation steps. An empty step means no flow is in progress.
+const (
+	BotFatherStepNewBotName     = "newbot_name"     // awaiting the new bot's display name
+	BotFatherStepNewBotUsername = "newbot_username" // awaiting the new bot's username
+	BotFatherStepRevokeSelect   = "revoke_select"   // awaiting which bot's token to revoke
+)
+
+// BotFatherState is a user's position in a multi-step BotFather flow.
+type BotFatherState struct {
+	Step      string
+	DraftName string // the pending bot name captured during /newbot
+}

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -55,12 +55,29 @@ MTProto session ↔ logged-in user binding.
 | about       | TEXT        | NOT NULL DEFAULT ''                  |
 | is_bot      | BOOLEAN     | NOT NULL DEFAULT FALSE               |
 | bot_token   | TEXT        | UNIQUE (set for bot accounts)        |
+| bot_owner_id | BIGINT     | FK → users(id) (creator, for BotFather bots) |
 | photo_file_id | BIGINT    | FK → files(id)                       |
 | created_at  | TIMESTAMPTZ | NOT NULL DEFAULT now()               |
 
 Bots log in with `auth.importBotAuthorization`: the first login with a
 well-formed `<id>:<secret>` token auto-provisions a `is_bot` account holding
 that `bot_token`, and later logins reuse it.
+
+BotFather (a built-in bot seeded with the fixed id `93372553`) mints tokens
+interactively: DMs to it are answered inline by the server, and the `/newbot`
+flow creates a `bot_owner_id`-owned bot and returns its token.
+
+## botfather_sessions
+
+A user's position in a multi-step BotFather flow (e.g. `/newbot` asks for a
+name, then a username). The row is cleared when the flow completes or is
+canceled.
+
+| Column     | Type   | Constraints                                    |
+|------------|--------|------------------------------------------------|
+| user_id    | BIGINT | PRIMARY KEY, FK → users(id) ON DELETE CASCADE  |
+| step       | TEXT   | NOT NULL (e.g. `newbot_name`, `newbot_username`)|
+| draft_name | TEXT   | NOT NULL DEFAULT '' (pending bot name)         |
 
 ## bot_commands
 

--- a/e2e/botfather_test.go
+++ b/e2e/botfather_test.go
@@ -1,0 +1,122 @@
+package e2e
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/session"
+	"github.com/gotd/td/tg"
+
+	"github.com/gotd/teled"
+	"github.com/gotd/teled/teledtest"
+)
+
+// TestBotFatherNewBot drives the full BotFather /newbot flow over a real client:
+// resolve @BotFather, walk the name/username dialog, and confirm the minted
+// token both authenticates a bot and is listed by /mybots.
+func TestBotFatherNewBot(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	srv := teledtest.New(t)
+
+	storage := &session.StorageMemory{}
+	var token, botUsername string
+
+	require.NoError(t, srv.Run(ctx, storage, func(api *tg.Client) error {
+		signUp(ctx, t, api, "+4444444444", "Dave")
+
+		// BotFather resolves by username and is a bot.
+		resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: "BotFather"})
+		require.NoError(t, err)
+		bf := resolved.Users[0].(*tg.User)
+		require.Equal(t, teled.BotFatherID, bf.ID)
+		require.True(t, bf.Bot)
+		require.Equal(t, "BotFather", bf.Username)
+		peer := inputPeer(bf)
+
+		var seq int
+		say := func(text string) string {
+			seq++
+			_, err := api.MessagesSendMessage(ctx, &tg.MessagesSendMessageRequest{
+				Peer: peer, Message: text, RandomID: int64(seq),
+			})
+			require.NoError(t, err)
+			hist, err := api.MessagesGetHistory(ctx, &tg.MessagesGetHistoryRequest{Peer: peer, Limit: 1})
+			require.NoError(t, err)
+			msgs := hist.(*tg.MessagesMessages).Messages
+			require.NotEmpty(t, msgs)
+			return msgs[0].(*tg.Message).Message
+		}
+
+		require.Contains(t, say("/newbot"), "choose a name")
+		require.Contains(t, say("Dave's Test Bot"), "choose a username")
+		require.Contains(t, say("not_ending_in_b0t"), "invalid") // rejected, flow stays open
+		done := say("dave_e2e_bot")
+		require.Contains(t, done, "Congratulations")
+
+		token = extractToken(t, done)
+		require.Contains(t, token, ":")
+		botUsername = "dave_e2e_bot"
+
+		// The token prefix is the new bot's user id.
+		botID, err := strconv.ParseInt(strings.SplitN(token, ":", 2)[0], 10, 64)
+		require.NoError(t, err)
+		newBot, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: botUsername})
+		require.NoError(t, err)
+		require.Equal(t, botID, newBot.Users[0].(*tg.User).ID)
+		require.True(t, newBot.Users[0].(*tg.User).Bot)
+
+		// /mybots lists the freshly created bot and its token.
+		listed := say("/mybots")
+		require.Contains(t, listed, "@dave_e2e_bot")
+		require.Contains(t, listed, token)
+		return nil
+	}))
+
+	// The minted token authenticates as that very bot.
+	require.NoError(t, srv.Run(ctx, nil, func(api *tg.Client) error {
+		self := importBot(ctx, t, api, token)
+		require.True(t, self.Bot)
+		require.Equal(t, botUsername, self.Username)
+		return nil
+	}))
+}
+
+// TestBotFatherCancel verifies a /newbot flow can be abandoned with /cancel.
+func TestBotFatherCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	srv := teledtest.New(t)
+
+	require.NoError(t, srv.Run(ctx, nil, func(api *tg.Client) error {
+		signUp(ctx, t, api, "+5555555555", "Erin")
+		resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: "BotFather"})
+		require.NoError(t, err)
+		peer := inputPeer(resolved.Users[0].(*tg.User))
+
+		var seq int
+		say := func(text string) string {
+			seq++
+			_, err := api.MessagesSendMessage(ctx, &tg.MessagesSendMessageRequest{
+				Peer: peer, Message: text, RandomID: int64(seq),
+			})
+			require.NoError(t, err)
+			hist, err := api.MessagesGetHistory(ctx, &tg.MessagesGetHistoryRequest{Peer: peer, Limit: 1})
+			require.NoError(t, err)
+			return hist.(*tg.MessagesMessages).Messages[0].(*tg.Message).Message
+		}
+
+		require.Contains(t, say("/newbot"), "choose a name")
+		require.Equal(t, "Canceled.", say("/cancel"))
+		// After cancel, free text is no longer consumed by the flow.
+		require.Contains(t, say("some name"), "I don't understand")
+		// No bots were created.
+		require.Contains(t, say("/mybots"), "don't have any bots")
+		return nil
+	}))
+}

--- a/e2e/bots_test.go
+++ b/e2e/bots_test.go
@@ -1,4 +1,4 @@
-package rpc
+package e2e
 
 import (
 	"context"
@@ -8,21 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gotd/td/session"
-	"github.com/gotd/td/tdsync"
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/tg"
 	"github.com/gotd/td/tgerr"
-)
 
-// importBot logs in a bot by token and returns the resolved self user.
-func importBot(ctx context.Context, t *testing.T, api *tg.Client, token string) *tg.User {
-	t.Helper()
-	authResp, err := api.AuthImportBotAuthorization(ctx, &tg.AuthImportBotAuthorizationRequest{
-		APIID: telegram.TestAppID, APIHash: telegram.TestAppHash, BotAuthToken: token,
-	})
-	require.NoError(t, err)
-	return authResp.(*tg.AuthAuthorization).User.(*tg.User)
-}
+	"github.com/gotd/teled/teledtest"
+)
 
 // TestBotImportAuthorizationAndCommands covers the bot lifecycle: token login
 // (auto-provisioning then reuse), self-resolution carrying the Bot flag, and
@@ -30,14 +21,13 @@ func importBot(ctx context.Context, t *testing.T, api *tg.Client, token string) 
 func TestBotImportAuthorizationAndCommands(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	g := tdsync.NewCancellableGroup(ctx)
-	env := newTestEnv(t, ctx, g)
+	srv := teledtest.New(t)
 
 	const token = "424242:secret-bot-token"
 	storage := &session.StorageMemory{}
 	var botID int64
 
-	env.runClient(ctx, t, storage, func(api *tg.Client) {
+	require.NoError(t, srv.Run(ctx, storage, func(api *tg.Client) error {
 		self := importBot(ctx, t, api, token)
 		require.True(t, self.Self)
 		require.True(t, self.Bot)
@@ -83,59 +73,46 @@ func TestBotImportAuthorizationAndCommands(t *testing.T) {
 		cmds, err = api.BotsGetBotCommands(ctx, &tg.BotsGetBotCommandsRequest{Scope: &tg.BotCommandScopeDefault{}})
 		require.NoError(t, err)
 		require.Empty(t, cmds)
-	})
+		return nil
+	}))
 
 	// Re-login with the same token reuses the account (no new bot).
-	env.runClient(ctx, t, &session.StorageMemory{}, func(api *tg.Client) {
+	require.NoError(t, srv.Run(ctx, nil, func(api *tg.Client) error {
 		self := importBot(ctx, t, api, token)
 		require.Equal(t, botID, self.ID)
-	})
-
-	g.Cancel()
-	if err := g.Wait(); err != nil {
-		require.ErrorIs(t, err, context.Canceled)
-	}
+		return nil
+	}))
 }
 
 // TestBotImportAuthorizationInvalidToken rejects a token without the
 // "<id>:<secret>" shape.
 func TestBotImportAuthorizationInvalidToken(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	g := tdsync.NewCancellableGroup(ctx)
-	env := newTestEnv(t, ctx, g)
+	srv := teledtest.New(t)
 
-	env.runClient(ctx, t, &session.StorageMemory{}, func(api *tg.Client) {
+	require.NoError(t, srv.Run(ctx, nil, func(api *tg.Client) error {
 		_, err := api.AuthImportBotAuthorization(ctx, &tg.AuthImportBotAuthorizationRequest{
 			APIID: telegram.TestAppID, APIHash: telegram.TestAppHash, BotAuthToken: "not-a-valid-token",
 		})
 		require.True(t, tgerr.Is(err, "ACCESS_TOKEN_INVALID"))
-	})
-
-	g.Cancel()
-	if err := g.Wait(); err != nil {
-		require.ErrorIs(t, err, context.Canceled)
-	}
+		return nil
+	}))
 }
 
 // TestBotCommandsRequireBot rejects bot command management from a human account.
 func TestBotCommandsRequireBot(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	g := tdsync.NewCancellableGroup(ctx)
-	env := newTestEnv(t, ctx, g)
+	srv := teledtest.New(t)
 
-	env.runClient(ctx, t, &session.StorageMemory{}, func(api *tg.Client) {
+	require.NoError(t, srv.Run(ctx, nil, func(api *tg.Client) error {
 		signUp(ctx, t, api, "+3333333333", "Carol")
 		_, err := api.BotsSetBotCommands(ctx, &tg.BotsSetBotCommandsRequest{
 			Scope:    &tg.BotCommandScopeDefault{},
 			Commands: []tg.BotCommand{{Command: "start", Description: "x"}},
 		})
 		require.True(t, tgerr.Is(err, "USER_BOT_REQUIRED"))
-	})
-
-	g.Cancel()
-	if err := g.Wait(); err != nil {
-		require.ErrorIs(t, err, context.Canceled)
-	}
+		return nil
+	}))
 }

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -1,0 +1,57 @@
+// Package e2e exercises teled end-to-end through a real gotd client connected
+// to an in-process server started with teledtest — which doubles as a worked
+// example of embedding the server in tests.
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+// signUp registers a fresh account via the dev auth flow and returns self.
+func signUp(ctx context.Context, t *testing.T, api *tg.Client, phone, first string) *tg.User {
+	t.Helper()
+	sent, err := api.AuthSendCode(ctx, &tg.AuthSendCodeRequest{
+		PhoneNumber: phone, APIID: telegram.TestAppID, APIHash: telegram.TestAppHash, Settings: tg.CodeSettings{},
+	})
+	require.NoError(t, err)
+	code := sent.(*tg.AuthSentCode)
+	authResp, err := api.AuthSignUp(ctx, &tg.AuthSignUpRequest{
+		PhoneNumber: phone, PhoneCodeHash: code.PhoneCodeHash, FirstName: first,
+	})
+	require.NoError(t, err)
+	return authResp.(*tg.AuthAuthorization).User.(*tg.User)
+}
+
+// importBot logs in a bot by token and returns the resolved self user.
+func importBot(ctx context.Context, t *testing.T, api *tg.Client, token string) *tg.User {
+	t.Helper()
+	authResp, err := api.AuthImportBotAuthorization(ctx, &tg.AuthImportBotAuthorizationRequest{
+		APIID: telegram.TestAppID, APIHash: telegram.TestAppHash, BotAuthToken: token,
+	})
+	require.NoError(t, err)
+	return authResp.(*tg.AuthAuthorization).User.(*tg.User)
+}
+
+func inputPeer(u *tg.User) *tg.InputPeerUser {
+	return &tg.InputPeerUser{UserID: u.ID, AccessHash: u.AccessHash}
+}
+
+// extractToken pulls the token line out of BotFather's success message.
+func extractToken(t *testing.T, success string) string {
+	t.Helper()
+	lines := strings.Split(success, "\n")
+	for i, l := range lines {
+		if strings.Contains(l, "Use this token") && i+1 < len(lines) {
+			return strings.TrimSpace(lines[i+1])
+		}
+	}
+	t.Fatalf("no token in message: %q", success)
+	return ""
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -11,13 +11,10 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
-	"github.com/gotd/td/transport"
-
 	"github.com/gotd/teled/internal/key"
-	"github.com/gotd/teled/internal/mtproto"
 	"github.com/gotd/teled/internal/objstore"
 	"github.com/gotd/teled/internal/obs"
-	"github.com/gotd/teled/internal/rpc"
+	"github.com/gotd/teled/server"
 )
 
 func newRoot(a *application) *cobra.Command {
@@ -78,7 +75,7 @@ func (a *application) serve(ctx context.Context, providers obs.Providers) error 
 		return errors.Wrap(err, "failed to parse private key")
 	}
 
-	keys, database, cleanup, err := a.setupStorage(ctx, providers)
+	pool, cleanup, err := a.setupStorage(ctx, providers)
 	if err != nil {
 		return errors.Wrap(err, "setup storage")
 	}
@@ -95,19 +92,20 @@ func (a *application) serve(ctx context.Context, providers obs.Providers) error 
 	}
 
 	const dc = 1
-	opt := mtproto.ServerOptions{
-		DC:        dc,
-		Logger:    a.lg,
-		Keys:      keys,
-		Providers: providers,
-	}
 	a.lg.Info("Listening",
 		zap.String("addr", a.Addr()),
-		zap.Int("dc", opt.DC),
+		zap.Int("dc", dc),
 	)
-	handler := rpc.New(a.lg, database, store, dc, a.Host, a.Port, providers)
-	srv := mtproto.NewServer(mtproto.NewPrivateKey(k), mtproto.UnpackInvoke(handler), opt)
-	return srv.Serve(ctx, transport.Listen(transport.ObfuscatedListener(ln)))
+	srv := server.New(k, pool, store, server.Options{
+		DC:             dc,
+		Host:           a.Host,
+		Port:           a.Port,
+		Logger:         a.lg,
+		Obfuscated:     true,
+		TracerProvider: providers.TracerProvider,
+		MeterProvider:  providers.MeterProvider,
+	})
+	return srv.Serve(ctx, ln)
 }
 
 // setTelemetryDefaults makes telemetry opt-in by defaulting the OTEL exporters

--- a/internal/cmd/storage.go
+++ b/internal/cmd/storage.go
@@ -5,46 +5,46 @@ import (
 	"time"
 
 	"github.com/go-faster/errors"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 	"go.uber.org/zap"
 
 	"github.com/gotd/teled/internal/db"
-	"github.com/gotd/teled/internal/mtproto"
 	"github.com/gotd/teled/internal/obs"
 	"github.com/gotd/teled/internal/queue"
 )
 
-// setupStorage initializes persistence and returns the auth-key store plus a
-// cleanup function. With no --postgres-uri it falls back to in-memory keys so
-// the server is runnable standalone (keys are then lost on restart).
-func (a *application) setupStorage(ctx context.Context, providers obs.Providers) (mtproto.KeyStorage, *db.DB, func(), error) {
+// setupStorage initializes persistence and returns the PostgreSQL pool plus a
+// cleanup function. With no --postgres-uri it returns a nil pool so the server
+// runs standalone with in-memory auth keys (lost on restart).
+func (a *application) setupStorage(ctx context.Context, providers obs.Providers) (*pgxpool.Pool, func(), error) {
 	if a.PostgresURI == "" {
 		a.lg.Warn("No --postgres-uri set; auth keys are kept in memory and lost on restart")
-		return mtproto.NewInMemoryKeys(), nil, func() {}, nil
+		return nil, func() {}, nil
 	}
 
 	if err := db.Migrate(a.PostgresURI); err != nil {
-		return nil, nil, nil, errors.Wrap(err, "migrate")
+		return nil, nil, errors.Wrap(err, "migrate")
 	}
 
 	pool, err := db.Open(ctx, a.PostgresURI, providers)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "open database")
+		return nil, nil, errors.Wrap(err, "open database")
 	}
 
 	if err := queue.Migrate(ctx, pool); err != nil {
 		pool.Close()
-		return nil, nil, nil, errors.Wrap(err, "migrate queue")
+		return nil, nil, errors.Wrap(err, "migrate queue")
 	}
 
 	q, err := queue.New(pool, river.NewWorkers())
 	if err != nil {
 		pool.Close()
-		return nil, nil, nil, errors.Wrap(err, "new queue")
+		return nil, nil, errors.Wrap(err, "new queue")
 	}
 	if err := q.Start(ctx); err != nil {
 		pool.Close()
-		return nil, nil, nil, errors.Wrap(err, "start queue")
+		return nil, nil, errors.Wrap(err, "start queue")
 	}
 
 	cleanup := func() {
@@ -57,5 +57,5 @@ func (a *application) setupStorage(ctx context.Context, providers obs.Providers)
 	}
 
 	a.lg.Info("Connected to PostgreSQL")
-	return db.NewKeyStore(pool), db.New(pool), cleanup, nil
+	return pool, cleanup, nil
 }

--- a/internal/db/_migrations/000008_botfather.down.sql
+++ b/internal/db/_migrations/000008_botfather.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE botfather_sessions;
+
+DELETE FROM users WHERE id = 93372553;
+
+ALTER TABLE users DROP COLUMN bot_owner_id;

--- a/internal/db/_migrations/000008_botfather.up.sql
+++ b/internal/db/_migrations/000008_botfather.up.sql
@@ -1,0 +1,18 @@
+-- Bots created through BotFather are owned by the user who created them.
+ALTER TABLE users
+    ADD COLUMN bot_owner_id BIGINT REFERENCES users (id) ON DELETE CASCADE;
+
+-- BotFather is a built-in bot account: the server answers DMs to it directly.
+-- The fixed id mirrors real Telegram (93372553) and matches teled.BotFatherID.
+-- access_hash is fixed so clients can re-resolve it deterministically.
+INSERT INTO users (id, access_hash, username, first_name, is_bot)
+VALUES (93372553, 7264819913547, 'BotFather', 'BotFather', true);
+
+-- botfather_sessions tracks a user's position in a multi-step BotFather flow
+-- (e.g. /newbot asks for a name, then a username).
+CREATE TABLE botfather_sessions
+(
+    user_id    BIGINT PRIMARY KEY REFERENCES users (id) ON DELETE CASCADE,
+    step       TEXT   NOT NULL,
+    draft_name TEXT   NOT NULL DEFAULT ''
+);

--- a/internal/db/botfather.go
+++ b/internal/db/botfather.go
@@ -1,0 +1,47 @@
+package db
+
+import (
+	"context"
+	"errors"
+
+	gerrors "github.com/go-faster/errors"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gotd/teled"
+)
+
+// BotFatherState returns the user's pending BotFather flow. A zero-value state
+// (empty Step) and no error means no flow is in progress.
+func (db *DB) BotFatherState(ctx context.Context, userID int64) (teled.BotFatherState, error) {
+	var s teled.BotFatherState
+	err := db.pool.QueryRow(ctx,
+		`SELECT step, draft_name FROM botfather_sessions WHERE user_id = $1`, userID,
+	).Scan(&s.Step, &s.DraftName)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return teled.BotFatherState{}, nil
+	}
+	if err != nil {
+		return teled.BotFatherState{}, gerrors.Wrap(err, "query")
+	}
+	return s, nil
+}
+
+// SetBotFatherState upserts the user's pending BotFather flow.
+func (db *DB) SetBotFatherState(ctx context.Context, userID int64, s teled.BotFatherState) error {
+	if _, err := db.pool.Exec(ctx,
+		`INSERT INTO botfather_sessions (user_id, step, draft_name) VALUES ($1, $2, $3)
+		 ON CONFLICT (user_id) DO UPDATE SET step = EXCLUDED.step, draft_name = EXCLUDED.draft_name`,
+		userID, s.Step, s.DraftName,
+	); err != nil {
+		return gerrors.Wrap(err, "upsert")
+	}
+	return nil
+}
+
+// ClearBotFatherState ends any pending BotFather flow for the user.
+func (db *DB) ClearBotFatherState(ctx context.Context, userID int64) error {
+	if _, err := db.pool.Exec(ctx, `DELETE FROM botfather_sessions WHERE user_id = $1`, userID); err != nil {
+		return gerrors.Wrap(err, "delete")
+	}
+	return nil
+}

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
+	"strconv"
 	"strings"
 
 	sq "github.com/Masterminds/squirrel"
@@ -25,13 +26,14 @@ var userColumns = []string{
 	"last_name",
 	"about",
 	"is_bot",
+	"COALESCE(bot_token, '')",
 	"created_at",
 }
 
 func scanUser(row pgx.Row, u *teled.User) error {
 	return row.Scan(
 		&u.ID, &u.AccessHash, &u.Phone, &u.Username,
-		&u.FirstName, &u.LastName, &u.About, &u.IsBot, &u.CreatedAt,
+		&u.FirstName, &u.LastName, &u.About, &u.IsBot, &u.BotToken, &u.CreatedAt,
 	)
 }
 
@@ -94,6 +96,80 @@ func (db *DB) CreateBot(ctx context.Context, token, username, firstName string) 
 // BotByToken returns the bot account holding token, if any.
 func (db *DB) BotByToken(ctx context.Context, token string) (*teled.User, bool, error) {
 	return db.userBy(ctx, "bot_token = ?", token)
+}
+
+// CreateOwnedBot creates a bot owned by ownerID, mints its token as
+// "<bot_id>:<secret>" once the id is known, and returns the persisted account
+// (with BotToken populated).
+func (db *DB) CreateOwnedBot(ctx context.Context, username, firstName string, ownerID int64, secret string) (teled.User, error) {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return teled.User{}, gerrors.Wrap(err, "begin")
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var id int64
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO users (access_hash, username, first_name, is_bot, bot_owner_id)
+		 VALUES ($1, $2, $3, true, $4) RETURNING id`,
+		genAccessHash(), username, firstName, ownerID,
+	).Scan(&id); err != nil {
+		return teled.User{}, gerrors.Wrap(err, "insert")
+	}
+
+	token := strconv.FormatInt(id, 10) + ":" + secret
+	var u teled.User
+	if err := scanUser(tx.QueryRow(ctx,
+		`UPDATE users SET bot_token = $1 WHERE id = $2 RETURNING `+strings.Join(userColumns, ", "),
+		token, id,
+	), &u); err != nil {
+		return teled.User{}, gerrors.Wrap(err, "set token")
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return teled.User{}, gerrors.Wrap(err, "commit")
+	}
+	return u, nil
+}
+
+// SetBotToken replaces a bot's auth token, e.g. on /revoke. A missing bot is a
+// no-op.
+func (db *DB) SetBotToken(ctx context.Context, botID int64, token string) error {
+	if _, err := db.pool.Exec(ctx,
+		`UPDATE users SET bot_token = $1 WHERE id = $2 AND is_bot`, token, botID,
+	); err != nil {
+		return gerrors.Wrap(err, "update")
+	}
+	return nil
+}
+
+// BotsByOwner returns the bots created by ownerID, oldest first.
+func (db *DB) BotsByOwner(ctx context.Context, ownerID int64) ([]teled.User, error) {
+	q := psql.Select(userColumns...).From("users").
+		Where("bot_owner_id = ?", ownerID).OrderBy("id")
+	sql, args, err := q.ToSql()
+	if err != nil {
+		return nil, gerrors.Wrap(err, "build query")
+	}
+
+	rows, err := db.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, gerrors.Wrap(err, "query")
+	}
+	defer rows.Close()
+
+	var bots []teled.User
+	for rows.Next() {
+		var u teled.User
+		if err := scanUser(rows, &u); err != nil {
+			return nil, gerrors.Wrap(err, "scan")
+		}
+		bots = append(bots, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, gerrors.Wrap(err, "rows")
+	}
+	return bots, nil
 }
 
 func (db *DB) userBy(ctx context.Context, where string, arg any) (*teled.User, bool, error) {

--- a/internal/rpc/botfather.go
+++ b/internal/rpc/botfather.go
@@ -1,0 +1,287 @@
+package rpc
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/gotd/td/tg"
+
+	"github.com/gotd/teled"
+)
+
+// BotFather reply texts. Kept close to the real BotFather wording so client
+// code and tests that match on it feel familiar.
+const (
+	bfIntro = "I can help you create and manage Telegram bots. " +
+		"Use /newbot to create a new bot.\n\n" +
+		"Commands:\n" +
+		"/newbot - create a new bot\n" +
+		"/mybots - list your bots\n" +
+		"/token - show a bot's token\n" +
+		"/revoke - revoke a bot's token\n" +
+		"/cancel - cancel the current operation"
+	bfAskName     = "Alright, a new bot. How are we going to call it? Please choose a name for your bot."
+	bfAskUsername = "Good. Now let's choose a username for your bot. It must end in `bot`. " +
+		"Like this, for example: TetrisBot or tetris_bot."
+	bfAskRevoke     = "Choose a bot to revoke the token. Send its username, for example @tetris_bot."
+	bfCancelled     = "Canceled."
+	bfNothingToDo   = "There is no active command to cancel."
+	bfNoBots        = "You don't have any bots yet. Use /newbot to create one."
+	bfBadName       = "Sorry, this name is invalid. Please choose a name for your bot."
+	bfNotUnderstood = "I don't understand. Please use /help to see the list of commands."
+)
+
+// handleBotFather runs the BotFather engine for an incoming DM and delivers its
+// replies as messages from BotFather to the caller. It is best-effort: failures
+// are logged, never surfaced to the sending client.
+func (h *Handler) handleBotFather(ctx context.Context, caller, botFather teled.User, text string) {
+	replies, err := h.botFatherEngine(ctx, caller, text)
+	if err != nil {
+		h.lg.Error("botfather engine", zap.Error(err))
+		return
+	}
+	for _, reply := range replies {
+		sent, err := h.db.SendMessage(ctx, botFather.ID, caller.ID, reply, 0, 0)
+		if err != nil {
+			h.lg.Error("botfather reply", zap.Error(err))
+			return
+		}
+		incoming := dmMessage(teled.Message{
+			LocalID:    sent.RecipientLocalID,
+			FromUserID: botFather.ID,
+			PeerUserID: botFather.ID,
+			Out:        false,
+			Text:       reply,
+			Date:       sent.Date,
+		})
+		h.push(ctx, caller.ID,
+			[]tg.UserClass{toTGUser(botFather, false), toTGUser(caller, true)},
+			int(sent.Date.Unix()),
+			&tg.UpdateNewMessage{Message: incoming, Pts: sent.RecipientPts, PtsCount: 1},
+		)
+	}
+}
+
+// botFatherEngine maps an incoming message (plus any pending flow state) to
+// BotFather's replies, applying state changes and bot creation as side effects.
+func (h *Handler) botFatherEngine(ctx context.Context, caller teled.User, text string) ([]string, error) {
+	text = strings.TrimSpace(text)
+
+	if cmd, ok := botCommand(text); ok {
+		return h.botFatherCommand(ctx, caller, cmd)
+	}
+
+	state, err := h.db.BotFatherState(ctx, caller.ID)
+	if err != nil {
+		return nil, err
+	}
+	switch state.Step {
+	case teled.BotFatherStepNewBotName:
+		return h.botFatherSetName(ctx, caller, text)
+	case teled.BotFatherStepNewBotUsername:
+		return h.botFatherCreate(ctx, caller, state.DraftName, text)
+	case teled.BotFatherStepRevokeSelect:
+		return h.botFatherRevoke(ctx, caller, text)
+	default:
+		return []string{bfNotUnderstood}, nil
+	}
+}
+
+// botCommand extracts a lowercased "/command" head, dropping any "@botname"
+// suffix and arguments. ok is false when text is not a command.
+func botCommand(text string) (string, bool) {
+	if !strings.HasPrefix(text, "/") {
+		return "", false
+	}
+	head := strings.Fields(text)[0]
+	if at := strings.IndexByte(head, '@'); at >= 0 {
+		head = head[:at]
+	}
+	return strings.ToLower(head), true
+}
+
+func (h *Handler) botFatherCommand(ctx context.Context, caller teled.User, cmd string) ([]string, error) {
+	switch cmd {
+	case "/start", "/help":
+		return []string{bfIntro}, nil
+	case "/newbot":
+		if err := h.db.SetBotFatherState(ctx, caller.ID, teled.BotFatherState{Step: teled.BotFatherStepNewBotName}); err != nil {
+			return nil, err
+		}
+		return []string{bfAskName}, nil
+	case "/mybots", "/token":
+		return h.botFatherListBots(ctx, caller)
+	case "/revoke":
+		bots, err := h.db.BotsByOwner(ctx, caller.ID)
+		if err != nil {
+			return nil, err
+		}
+		if len(bots) == 0 {
+			return []string{bfNoBots}, nil
+		}
+		if err := h.db.SetBotFatherState(ctx, caller.ID, teled.BotFatherState{Step: teled.BotFatherStepRevokeSelect}); err != nil {
+			return nil, err
+		}
+		return []string{bfAskRevoke}, nil
+	case "/cancel":
+		state, err := h.db.BotFatherState(ctx, caller.ID)
+		if err != nil {
+			return nil, err
+		}
+		if state.Step == "" {
+			return []string{bfNothingToDo}, nil
+		}
+		if err := h.db.ClearBotFatherState(ctx, caller.ID); err != nil {
+			return nil, err
+		}
+		return []string{bfCancelled}, nil
+	default:
+		return []string{bfNotUnderstood}, nil
+	}
+}
+
+func (h *Handler) botFatherListBots(ctx context.Context, caller teled.User) ([]string, error) {
+	bots, err := h.db.BotsByOwner(ctx, caller.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(bots) == 0 {
+		return []string{bfNoBots}, nil
+	}
+	var b strings.Builder
+	b.WriteString("Here are your bots:\n")
+	for _, bot := range bots {
+		fmt.Fprintf(&b, "\n@%s\n%s", bot.Username, bot.BotToken)
+	}
+	return []string{b.String()}, nil
+}
+
+func (h *Handler) botFatherSetName(ctx context.Context, caller teled.User, name string) ([]string, error) {
+	if !validBotName(name) {
+		return []string{bfBadName}, nil
+	}
+	if err := h.db.SetBotFatherState(ctx, caller.ID, teled.BotFatherState{
+		Step:      teled.BotFatherStepNewBotUsername,
+		DraftName: name,
+	}); err != nil {
+		return nil, err
+	}
+	return []string{bfAskUsername}, nil
+}
+
+func (h *Handler) botFatherCreate(ctx context.Context, caller teled.User, name, username string) ([]string, error) {
+	username = strings.TrimPrefix(username, "@")
+	if msg, ok := validBotUsername(username); !ok {
+		return []string{msg}, nil
+	}
+
+	if _, taken, err := h.db.UserByUsername(ctx, username); err != nil {
+		return nil, err
+	} else if taken {
+		return []string{"Sorry, this username is already taken. Please try something different."}, nil
+	}
+
+	secret, err := botTokenSecret()
+	if err != nil {
+		return nil, err
+	}
+	bot, err := h.db.CreateOwnedBot(ctx, username, name, caller.ID, secret)
+	if err != nil {
+		return nil, err
+	}
+	if err := h.db.ClearBotFatherState(ctx, caller.ID); err != nil {
+		return nil, err
+	}
+
+	return []string{fmt.Sprintf(
+		"Done! Congratulations on your new bot. You will find it at t.me/%s.\n\n"+
+			"Use this token to access the HTTP API:\n%s\n\n"+
+			"Keep your token secure and store it safely, it can be used by anyone to control your bot.",
+		bot.Username, bot.BotToken,
+	)}, nil
+}
+
+func (h *Handler) botFatherRevoke(ctx context.Context, caller teled.User, username string) ([]string, error) {
+	username = strings.TrimPrefix(username, "@")
+	bots, err := h.db.BotsByOwner(ctx, caller.ID)
+	if err != nil {
+		return nil, err
+	}
+	var target *teled.User
+	for i := range bots {
+		if strings.EqualFold(bots[i].Username, username) {
+			target = &bots[i]
+			break
+		}
+	}
+	if target == nil {
+		return []string{"You don't own a bot with that username. Send the username of one of your bots."}, nil
+	}
+
+	secret, err := botTokenSecret()
+	if err != nil {
+		return nil, err
+	}
+	token := fmt.Sprintf("%d:%s", target.ID, secret)
+	if err := h.db.SetBotToken(ctx, target.ID, token); err != nil {
+		return nil, err
+	}
+	if err := h.db.ClearBotFatherState(ctx, caller.ID); err != nil {
+		return nil, err
+	}
+	return []string{fmt.Sprintf(
+		"Token revoked. The previous token has stopped working.\n\n"+
+			"New token for @%s:\n%s", target.Username, token,
+	)}, nil
+}
+
+// validBotName accepts any non-empty, reasonably short, non-command name.
+func validBotName(name string) bool {
+	return name != "" && len(name) <= 64 && !strings.HasPrefix(name, "/")
+}
+
+// validBotUsername enforces BotFather's username rules, returning the
+// user-facing error when invalid.
+func validBotUsername(u string) (string, bool) {
+	const help = "Sorry, this username is invalid. A username must be 5-32 characters long, " +
+		"start with a letter, use only letters, digits and underscores, and end in `bot`."
+	if len(u) < 5 || len(u) > 32 {
+		return help, false
+	}
+	if !isASCIILetter(u[0]) {
+		return help, false
+	}
+	for i := 0; i < len(u); i++ {
+		if !isUsernameChar(u[i]) {
+			return help, false
+		}
+	}
+	if !strings.HasSuffix(strings.ToLower(u), "bot") {
+		return help, false
+	}
+	return "", true
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// isUsernameChar reports whether c is allowed in a bot username.
+func isUsernameChar(c byte) bool {
+	return isASCIILetter(c) || (c >= '0' && c <= '9') || c == '_'
+}
+
+// botTokenSecret returns the part of a bot token after the colon: 35 URL-safe
+// characters, matching the shape of a real BotFather token secret.
+func botTokenSecret() (string, error) {
+	var raw [26]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}

--- a/internal/rpc/messages.go
+++ b/internal/rpc/messages.go
@@ -46,6 +46,12 @@ func (h *Handler) messagesSendMessage(ctx context.Context, req *tg.MessagesSendM
 
 	h.deliver(ctx, caller, peer, sent, req.Message)
 
+	// BotFather answers DMs to it inline: its replies are persisted and pushed
+	// before this RPC returns, so they are immediately visible in history.
+	if peer.ID == teled.BotFatherID {
+		h.handleBotFather(ctx, caller, peer, req.Message)
+	}
+
 	return &tg.Updates{
 		Updates: []tg.UpdateClass{
 			&tg.UpdateMessageID{ID: int(sent.SenderLocalID), RandomID: req.RandomID},

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,115 @@
+// Package server assembles teled's storage, RPC handlers and MTProto transport
+// into a single embeddable Telegram server.
+//
+// It is the same wiring the teled binary uses, exposed as a library so that
+// programs and tests can run a real Telegram server in-process. For a turnkey
+// test harness (throwaway PostgreSQL, random port, ready-made client) see
+// github.com/gotd/teled/teledtest.
+package server
+
+import (
+	"context"
+	"crypto/rsa"
+	"net"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/transport"
+
+	"github.com/gotd/teled"
+	"github.com/gotd/teled/internal/db"
+	"github.com/gotd/teled/internal/mtproto"
+	"github.com/gotd/teled/internal/obs"
+	"github.com/gotd/teled/internal/rpc"
+)
+
+// Migrate applies teled's schema migrations to the PostgreSQL database at dsn.
+// Call it once before opening a pool for New.
+func Migrate(dsn string) error { return db.Migrate(dsn) }
+
+// Options configures a Server. The zero value is valid: DC defaults to 1,
+// Logger to a no-op, and telemetry to no-op providers.
+type Options struct {
+	// DC is this server's datacenter id, advertised in help.getConfig.
+	DC int
+	// Host and Port are the address advertised to clients in the DC options of
+	// help.getConfig. They should match how clients reach the listener.
+	Host string
+	Port int
+	// Logger receives server logs. Defaults to zap.NewNop.
+	Logger *zap.Logger
+	// Obfuscated wraps the listener in MTProto's obfuscated transport, as the
+	// production server does. Leave false to auto-detect the transport codec,
+	// which is what in-process test clients use.
+	Obfuscated bool
+	// TracerProvider and MeterProvider instrument the server. Nil yields no-op.
+	TracerProvider trace.TracerProvider
+	MeterProvider  metric.MeterProvider
+}
+
+// Server is an embeddable teled Telegram server. Construct it with New and run
+// it with Serve.
+type Server struct {
+	srv        *mtproto.Server
+	dc         int
+	obfuscated bool
+}
+
+// New assembles a server from a private key and storage. pool is a PostgreSQL
+// pool already migrated with Migrate; pass nil to run with in-memory auth keys
+// and no persistence (most RPCs then return NOT_IMPLEMENTED). store backs media
+// upload/download and may be nil when media is unused.
+func New(key *rsa.PrivateKey, pool *pgxpool.Pool, store teled.ObjectStore, opts Options) *Server {
+	if opts.DC == 0 {
+		opts.DC = 1
+	}
+	if opts.Logger == nil {
+		opts.Logger = zap.NewNop()
+	}
+	providers := obs.Providers{
+		TracerProvider: opts.TracerProvider,
+		MeterProvider:  opts.MeterProvider,
+	}
+
+	var (
+		database *db.DB
+		keys     mtproto.KeyStorage
+	)
+	if pool != nil {
+		database = db.New(pool)
+		keys = db.NewKeyStore(pool)
+	} else {
+		keys = mtproto.NewInMemoryKeys()
+	}
+
+	handler := rpc.New(opts.Logger.Named("rpc"), database, store, opts.DC, opts.Host, opts.Port, providers)
+	srv := mtproto.NewServer(mtproto.NewPrivateKey(key), mtproto.UnpackInvoke(handler), mtproto.ServerOptions{
+		DC:        opts.DC,
+		Logger:    opts.Logger.Named("mtproto"),
+		Keys:      keys,
+		Providers: providers,
+	})
+	return &Server{srv: srv, dc: opts.DC, obfuscated: opts.Obfuscated}
+}
+
+// Serve accepts and handles MTProto connections on ln until ctx is canceled.
+func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
+	var l transport.Listener
+	if s.obfuscated {
+		l = transport.Listen(transport.ObfuscatedListener(ln))
+	} else {
+		l = transport.ListenCodec(nil, ln)
+	}
+	return s.srv.Serve(ctx, l)
+}
+
+// Key returns the server's public key, for clients to pin via
+// telegram.Options.PublicKeys.
+func (s *Server) Key() telegram.PublicKey { return s.srv.Key() }
+
+// DC returns the server's datacenter id.
+func (s *Server) DC() int { return s.dc }

--- a/teledtest/teledtest.go
+++ b/teledtest/teledtest.go
@@ -1,0 +1,151 @@
+// Package teledtest runs a real teled Telegram server in-process for tests.
+//
+// New starts a fully-migrated server on a random local port backed by a
+// throwaway PostgreSQL container, shut down automatically on test cleanup. It is
+// the embeddable counterpart to gotd's tgtest: where tgtest makes you stub each
+// RPC by hand, teledtest gives you the actual teled implementation (auth, DMs,
+// media, bots, BotFather) to test a client against.
+//
+//	srv := teledtest.New(t)
+//	err := srv.Run(ctx, nil, func(api *tg.Client) error {
+//	    _, err := api.HelpGetConfig(ctx)
+//	    return err
+//	})
+package teledtest
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/gotd/td/crypto"
+	"github.com/gotd/td/session"
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/telegram/dcs"
+	"github.com/gotd/td/tg"
+
+	"github.com/gotd/teled/internal/db"
+	"github.com/gotd/teled/internal/objstore"
+	"github.com/gotd/teled/internal/obs"
+	"github.com/gotd/teled/internal/pgtest"
+	"github.com/gotd/teled/server"
+)
+
+// dc is the datacenter id the in-process server advertises and clients dial.
+const dc = 2
+
+// Server is a running in-process teled server with helpers to connect clients.
+type Server struct {
+	// DC is the datacenter id clients should dial.
+	DC int
+	// Addr is the server's listen address.
+	Addr *net.TCPAddr
+	// Keys are the server public keys, for telegram.Options.PublicKeys.
+	Keys []telegram.PublicKey
+
+	tb   testing.TB
+	pool *pgxpool.Pool
+}
+
+// New starts a teled server backed by a throwaway PostgreSQL container and
+// returns it. The server, database and connections are torn down on test
+// cleanup. The test is skipped on hosts without container support.
+func New(tb testing.TB) *Server {
+	tb.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tb.Cleanup(cancel)
+
+	dsn := pgtest.New(tb) // skips the test when containers are unavailable.
+	if err := server.Migrate(dsn); err != nil {
+		tb.Fatalf("teledtest: migrate: %v", err)
+	}
+	pool, err := db.Open(ctx, dsn, obs.Providers{})
+	if err != nil {
+		tb.Fatalf("teledtest: open db: %v", err)
+	}
+	tb.Cleanup(pool.Close)
+
+	key, err := rsa.GenerateKey(rand.Reader, crypto.RSAKeyBits)
+	if err != nil {
+		tb.Fatalf("teledtest: generate key: %v", err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatalf("teledtest: listen: %v", err)
+	}
+	addr := ln.Addr().(*net.TCPAddr)
+	store, err := objstore.NewFS(tb.TempDir(), obs.Providers{})
+	if err != nil {
+		tb.Fatalf("teledtest: object store: %v", err)
+	}
+
+	lg := zaptest.NewLogger(tb, zaptest.Level(zapcore.WarnLevel))
+	srv := server.New(key, pool, store, server.Options{
+		DC:     dc,
+		Host:   addr.IP.String(),
+		Port:   addr.Port,
+		Logger: lg,
+	})
+
+	done := make(chan struct{})
+	var serveErr error
+	go func() {
+		defer close(done)
+		serveErr = srv.Serve(ctx, ln)
+	}()
+	tb.Cleanup(func() {
+		cancel()
+		<-done
+		if serveErr != nil && !errors.Is(serveErr, context.Canceled) {
+			tb.Errorf("teledtest: serve: %v", serveErr)
+		}
+	})
+
+	return &Server{
+		DC:   dc,
+		Addr: addr,
+		Keys: []telegram.PublicKey{srv.Key()},
+		tb:   tb,
+		pool: pool,
+	}
+}
+
+// Pool returns the server's PostgreSQL pool, for tests that assert on stored
+// state directly.
+func (s *Server) Pool() *pgxpool.Pool { return s.pool }
+
+// Client builds a gotd client wired to this server. A nil storage uses a fresh
+// in-memory session.
+func (s *Server) Client(storage session.Storage) *telegram.Client {
+	if storage == nil {
+		storage = &session.StorageMemory{}
+	}
+	return telegram.NewClient(telegram.TestAppID, telegram.TestAppHash, telegram.Options{
+		PublicKeys:     s.Keys,
+		DC:             s.DC,
+		DCList:         dcs.List{Options: []tg.DCOption{{ID: s.DC, IPAddress: s.Addr.IP.String(), Port: s.Addr.Port}}},
+		Resolver:       dcs.Plain(dcs.PlainOptions{}),
+		NoUpdates:      true,
+		Logger:         zaptest.NewLogger(s.tb, zaptest.Level(zapcore.WarnLevel)).Named("client"),
+		SessionStorage: storage,
+		RetryInterval:  100 * time.Millisecond,
+	})
+}
+
+// Run connects a client (using storage, or a fresh in-memory session when nil),
+// invokes fn with the raw API, and disconnects.
+func (s *Server) Run(ctx context.Context, storage session.Storage, fn func(api *tg.Client) error) error {
+	client := s.Client(storage)
+	return client.Run(ctx, func(ctx context.Context) error {
+		return fn(client.API())
+	})
+}

--- a/users.go
+++ b/users.go
@@ -11,6 +11,7 @@ type User struct {
 	FirstName  string
 	LastName   string
 	About      string
-	IsBot      bool // true for bot accounts authenticated by token
+	IsBot      bool   // true for bot accounts authenticated by token
+	BotToken   string // bot auth token, empty for human accounts
 	CreatedAt  time.Time
 }


### PR DESCRIPTION
## Summary

Improves bot support in the teled test server across three layers, plus extracts the server into an embeddable library for testing.

### Bot login, identity & commands
- `auth.importBotAuthorization`: bots authenticate by `<id>:<secret>` token. First login with a well-formed token auto-provisions the account (mirroring how `authSignUp` auto-creates users); later logins reuse it.
- The `Bot` flag now flows through `tg.User` wire forms, so `users.getUsers`, `getFullUser`, `resolveUsername` and messages all report bots correctly.
- `bots.setBotCommands` / `getBotCommands` / `resetBotCommands`, storage-backed and scoped per `(scope, language)` with lossless scope keys. Gated to bot callers (`USER_BOT_REQUIRED`).

### Built-in BotFather
- A seeded BotFather account (fixed id `93372553`, resolvable by username) answers DMs inline.
- The `/newbot` flow walks a name → username dialog, validates the username (BotFather's rules), creates an owned bot, and returns its token. `/mybots`, `/token`, `/revoke`, `/cancel` round out management.
- Minted tokens log in via the `auth.importBotAuthorization` path above. Conversation state persists per user in `botfather_sessions`; bots track their creator via `users.bot_owner_id`.

### Embeddable server library
- New `github.com/gotd/teled/server` package: the server assembly (storage + RPC + MTProto) extracted out of `cmd`. `cmd` now builds via `server.New`, so production and tests share one path.
- New `github.com/gotd/teled/teledtest` package: a turnkey harness that boots a fully-migrated server on a random port over a throwaway PostgreSQL container. Unlike gotd's `tgtest` (stub each RPC by hand), it runs the real teled implementation.
- Bots + BotFather e2e tests moved to a new `e2e` package built on `teledtest`, dropping the hand-rolled harness.

## Testing
- `go build ./...`, `go vet ./...`, `golangci-lint run` — all clean (0 issues).
- Full container-backed test suite passes, including the new `e2e` package driving a real gotd client through token login, command round trips, and the full BotFather `/newbot` flow (with the minted token then authenticating a bot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)